### PR TITLE
[DOC] Tell users to serialize sequence with abstract representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Updated Readme to tell users to use the abstract representation of a sequence instead of python serialization when creating a batch.
+
 ## [0.1.14]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ omega_max = sequence.declare_variable("omega_max")
 generic_pulse = Pulse.ConstantPulse(100, omega_max, 2, 0.0)
 sequence.add(generic_pulse, "rydberg")
 
-# When you are done building your sequence, serialize it into a string
-serialized_sequence = sequence.serialize()
+# When you are done building your sequence, serialize it into a string using the abstract representation
+serialized_sequence = sequence.to_abstract_repr()
 ```
 
 Once you have serialized your sequence, you can send it with the SDK with the following code


### PR DESCRIPTION
The backend expects sequences serialized with the abstract representation. The documentation was outdated on that front.