### PR TITLE
[FIX] Reinstate fetch results

### DIFF
--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -114,7 +114,9 @@ class SDK:
         """
         if fetch_results:
             warn(
-                ("The parameter fetch_results has no effect and is deprecated."),
+                (
+                    "The parameter fetch_results will soon be deprecated. Please start using the `wait` parameter instead."
+                ),
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -137,7 +139,7 @@ class SDK:
 
         batch_rsp = self._client._send_batch(req)
         batch_id = batch_rsp["id"]
-        if wait:
+        if wait or fetch_results:
             while batch_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
                 batch_rsp = self._client._get_batch(batch_id)
@@ -158,7 +160,9 @@ class SDK:
         """
         if fetch_results:
             warn(
-                ("The parameter fetch_results has no effect and is deprecated."),
+                (
+                    "The parameter fetch_results will soon be deprecated. Results are fetched anyway with this function."
+                ),
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
Removing the functionality of this argument was not required _and_ broke some user scripts by breaking the integration with `qoolbox`. This reinstates the functionality of the argument while keeping the DeprecationWarning. 