### PR TITLE
[FIX] Reinstate fetch results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2023-07-05
+
+### Added
+
+Reinstated the full functionality for the `fetch_results` argument as well as the corresponding test.
+
 ## [0.3.2] - 2023-07-03
 
 ### Added

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -114,7 +114,9 @@ class SDK:
         """
         if fetch_results:
             warn(
-                ("The parameter fetch_results has no effect and is deprecated."),
+                (
+                    "The parameter fetch_results will soon be deprecated. Please start using the `wait` parameter instead."
+                ),
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -137,7 +139,7 @@ class SDK:
 
         batch_rsp = self._client._send_batch(req)
         batch_id = batch_rsp["id"]
-        if wait:
+        if wait or fetch_results:
             while batch_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
                 batch_rsp = self._client._get_batch(batch_id)
@@ -158,7 +160,9 @@ class SDK:
         """
         if fetch_results:
             warn(
-                ("The parameter fetch_results has no effect and is deprecated."),
+                (
+                    "The parameter fetch_results will soon be deprecated. Results are fetched anyway with this function."
+                ),
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -19,9 +19,8 @@ from warnings import warn
 from pasqal_cloud.authentication import TokenProvider
 from pasqal_cloud.batch import Batch, RESULT_POLLING_INTERVAL
 from pasqal_cloud.client import Client
-from pasqal_cloud.device import BaseConfig
-from pasqal_cloud.device import EmulatorType
-from pasqal_cloud.endpoints import Auth0Conf, Endpoints, PASQAL_ENDPOINTS, AUTH0_CONFIG
+from pasqal_cloud.device import BaseConfig, EmulatorType
+from pasqal_cloud.endpoints import Auth0Conf, Endpoints
 from pasqal_cloud.job import Job
 
 
@@ -49,7 +48,8 @@ class SDK:
         Args:
             username: email of the user to login as.
             password: password of the user to login as.
-            token_provider: The token provider is an alternative log-in method not for human users.
+            token_provider: The token provider is an alternative log-in method \
+                not for human users.
             webhook: Webhook where the job results are automatically sent to.
             endpoints: Endpoints targeted of the public apis.
             auth0: Auth0Config object to define the auth0 tenant to target.
@@ -57,17 +57,16 @@ class SDK:
             group_id (deprecated): Use project_id instead.
         """
 
-        # Ticket (#622), to be removed, used to avoid a breaking change during the group to project renaming
+        # Ticket (#622), to be removed,
+        # used to avoid a breaking change during the group to project renaming
         if not project_id:
             if not group_id:
                 raise TypeError(
                     "Either a 'group_id' or 'project_id' has to be given as argument"
                 )
             warn(
-                (
-                    "The parameter 'group_id' is deprecated, from now on use"
-                    " 'project_id' instead"
-                ),
+                "The parameter 'group_id' is deprecated, from now on use"
+                " 'project_id' instead",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -114,9 +113,8 @@ class SDK:
         """
         if fetch_results:
             warn(
-                (
-                    "The parameter fetch_results will soon be deprecated. Please start using the `wait` parameter instead."
-                ),
+                "Argument `fetch_results` is deprecated and will be removed in a future"
+                " version. Please use argument `wait` instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -160,9 +158,8 @@ class SDK:
         """
         if fetch_results:
             warn(
-                (
-                    "The parameter fetch_results will soon be deprecated. Results are fetched anyway with this function."
-                ),
+                "Argument `fetch_results` is deprecated and will be removed in a future"
+                " version. Results are fetched anyway with this function.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,12 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+order_by_type = false
+force_alphabetical_sort_within_sections = true
+
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ license_files = LICENSE
 [flake8]
 # Using black's max line length
 max-line-length = 88
-exclude = tests
+exclude = tests/
 
 application-import-names=sdk
 application-package-names=sdk

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -2,10 +2,10 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
-from pasqal_cloud import SDK, Batch, Job
+from pasqal_cloud import Batch, Job, SDK
 from pasqal_cloud.device import BaseConfig, EmuFreeConfig, EmulatorType, EmuTNConfig
+from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
 
 class TestBatch:
@@ -41,10 +41,14 @@ class TestBatch:
         assert batch.jobs[self.job_id].batch_id == batch.id
         assert batch.jobs[self.job_id].runs == self.n_job_runs
 
-    def test_create_batch_and_wait(self, request_mock):
+    @pytest.mark.parametrize("wait,fetch_results", [(True, False), (False, True)])
+    def test_create_batch_and_wait(self, request_mock, wait, fetch_results):
         job = {"runs": self.n_job_runs, "variables": self.job_variables}
         batch = self.sdk.create_batch(
-            serialized_sequence=self.pulser_sequence, jobs=[job], wait=True
+            serialized_sequence=self.pulser_sequence,
+            jobs=[job],
+            wait=wait,
+            fetch_results=fetch_results,
         )
         assert (
             batch.id == "00000000-0000-0000-0000-000000000001"


### PR DESCRIPTION
Removing the functionality of this argument was not required and broke some user scripts by breaking the integration with qoolbox. This reinstates the functionality of the argument while keeping the DeprecationWarning.

(Moved over from https://github.com/pasqal-io/pasqal-cloud/pull/93 bc of a Github issue). 