### PR TITLE
[FEAT] Workload support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2023-07-18
+
+### Added
+
+Workloads are now supported by the sdk with the create_workload, get_workload and cancel_workload methods.
+
 ## [0.3.3] - 2023-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ for job in batch.jobs.values():
 
 ```
 
+### Workload Creation
+
+You can create a workload through the SDK with the following command: 
+```python
+workload=sdk.create_workload(workload_type="<WORKLOAD_TYPE>",backend="<BACKEND>",config={"config_param_1":"value"})
+
+#You can cancel the workload by doing:
+sdk.cancel_workload(workload.id)
+
+#Or refresh the workload status/results by with the following:
+workload=sdk.get_workload(workload.id)
+
+#Once the workload has been processed you can fetch the result like this:
+print(workload.result)
+```
+
+
 ## Advanced usage
 
 ### Authentication

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -87,6 +87,7 @@ class SDK:
             auth0=auth0,
         )
         self.batches: Dict[str, Batch] = {}
+        self.workloads: Dict[str,Workload] ={}
         self.webhook = webhook
 
     def create_batch(
@@ -219,23 +220,23 @@ class SDK:
                     workload_type: str,
                     backend: str,
                     config: Dict[str,Any],
-                    wait: bool = False,):
+                    wait: bool = False,)->Workload:
         req = {
             "workload_type": workload_type,
             "backend": backend,
             "config": config,
         }
-        batch_rsp = self._client._send_workload(req)
-        batch_id = batch_rsp["id"]
+        workload_rsp = self._client._send_workload(req)
+        workload_id = workload_rsp["id"]
         if wait:
             while batch_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
-                batch_rsp = self._client._get_batch(batch_id)
+                batch_rsp = self._client._get_workload(workload_id)
 
-        batch = Batch(**batch_rsp, _client=self._client)
+        workload = Workload(**workload_rsp, _client=self._client)
 
-        self.batches[batch.id] = batch
-        return batch
+        self.workloads[workload.id] = workload
+        return workload
 
     def get_workload(self,id:str, wait: bool = False)->Workload:
         """Retrieve a workload's data.

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -87,7 +87,7 @@ class SDK:
             auth0=auth0,
         )
         self.batches: Dict[str, Batch] = {}
-        self.workloads: Dict[str,Workload] ={}
+        self.workloads: Dict[str, Workload] = {}
         self.webhook = webhook
 
     def create_batch(
@@ -216,11 +216,13 @@ class SDK:
         job = Job(**job_rsp, _client=self._client)
         return job
 
-    def create_workload(self,
-                    workload_type: str,
-                    backend: str,
-                    config: Dict[str,Any],
-                    wait: bool = False,)->Workload:
+    def create_workload(
+        self,
+        workload_type: str,
+        backend: str,
+        config: Dict[str, Any],
+        wait: bool = False,
+    ) -> Workload:
         req = {
             "workload_type": workload_type,
             "backend": backend,
@@ -231,23 +233,23 @@ class SDK:
         if wait:
             while workload_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
-                batch_rsp = self._client._get_workload(workload_id)
+                workload_rsp = self._client._get_workload(workload_id)
 
         workload = Workload(**workload_rsp, _client=self._client)
 
         self.workloads[workload.id] = workload
         return workload
 
-    def get_workload(self,id:str, wait: bool = False)->Workload:
+    def get_workload(self, id: str, wait: bool = False) -> Workload:
         """Retrieve a workload's data.
 
-                Args:
-                    id: ID of the workload.
-                    wait: Whether to wait for the workload to be done
+        Args:
+            id: ID of the workload.
+            wait: Whether to wait for the workload to be done
 
-                Returns:
-                    Job: the workload stored in the PCS database.
-                """
+        Returns:
+            Job: the workload stored in the PCS database.
+        """
         workload_rsp = self._client._get_workload(id)
         if wait:
             while workload_rsp["status"] in ["PENDING", "RUNNING"]:
@@ -256,18 +258,15 @@ class SDK:
         workload = Workload(**workload_rsp, _client=self._client)
         return workload
 
-    def cancel_workload(self,id:str)->Workload:
+    def cancel_workload(self, id: str) -> Workload:
         """Cancel the given workload on the PCS
 
-                Args:
-                    id: Workload id.
-                """
+        Args:
+            id: Workload id.
+        """
         workload_rsp = self._client._cancel_workload(id)
         workload = Workload(**workload_rsp, _client=self._client)
         return workload
-
-
-
 
     def get_device_specs_dict(self) -> Dict[str, str]:
         """Retrieve the list of available device specifications.

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -225,7 +225,7 @@ class SDK:
             "backend": backend,
             "config": config,
         }
-        batch_rsp = self._client.send_workload(req)
+        batch_rsp = self._client._send_workload(req)
         batch_id = batch_rsp["id"]
         if wait:
             while batch_rsp["status"] in ["PENDING", "RUNNING"]:

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -27,6 +27,7 @@ from pasqal_cloud.endpoints import (  # noqa: F401
     PASQAL_ENDPOINTS,
 )
 from pasqal_cloud.job import Job
+from pasqal_cloud.workload import Workload
 
 
 class SDK:
@@ -213,6 +214,59 @@ class SDK:
         job_rsp = self._client._cancel_job(id)
         job = Job(**job_rsp, _client=self._client)
         return job
+
+    def create_workload(self,
+                    workload_type: str,
+                    backend: str,
+                    config: Dict[str,Any],
+                    wait: bool = False,):
+        req = {
+            "workload_type": workload_type,
+            "backend": backend,
+            "config": config,
+        }
+        batch_rsp = self._client.send_workload(req)
+        batch_id = batch_rsp["id"]
+        if wait:
+            while batch_rsp["status"] in ["PENDING", "RUNNING"]:
+                time.sleep(RESULT_POLLING_INTERVAL)
+                batch_rsp = self._client._get_batch(batch_id)
+
+        batch = Batch(**batch_rsp, _client=self._client)
+
+        self.batches[batch.id] = batch
+        return batch
+
+    def get_workload(self,id:str, wait: bool = False)->Workload:
+        """Retrieve a workload's data.
+
+                Args:
+                    id: ID of the workload.
+                    wait: Whether to wait for the workload to be done
+
+                Returns:
+                    Job: the workload stored in the PCS database.
+                """
+        workload_rsp = self._client._get_workload(id)
+        if wait:
+            while workload_rsp["status"] in ["PENDING", "RUNNING"]:
+                time.sleep(RESULT_POLLING_INTERVAL)
+                workload_rsp = self._client._get_job(id)
+        workload = Workload(**workload_rsp, _client=self._client)
+        return workload
+
+    def cancel_workload(self,id:str)->Workload:
+        """Cancel the given workload on the PCS
+
+                Args:
+                    id: Workload id.
+                """
+        workload_rsp = self._client._cancel_workload(id)
+        workload = Workload(**workload_rsp, _client=self._client)
+        return workload
+
+
+
 
     def get_device_specs_dict(self) -> Dict[str, str]:
         """Retrieve the list of available device specifications.

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -229,7 +229,7 @@ class SDK:
         workload_rsp = self._client._send_workload(req)
         workload_id = workload_rsp["id"]
         if wait:
-            while batch_rsp["status"] in ["PENDING", "RUNNING"]:
+            while workload_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
                 batch_rsp = self._client._get_workload(workload_id)
 

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -159,6 +159,26 @@ class Client:
         )["data"]
         return job
 
+    def _send_workload(self, workload_data: Dict[str, Any]) -> Dict[str, Any]:
+        workload_data.update({"project_id": self.project_id})
+        workload_data = self._request(
+            "POST",
+            f"{self.endpoints.core}/api/v1/workloads",
+            workload_data,
+        )["data"]
+        return workload_data
+
+    def _get_workload(self, workload_id: str) -> Dict[str, Any]:
+        workload: Dict[str, Any] = self._request(
+            "GET", f"{self.endpoints.core}/api/v1/workloads/{workload_id}"
+        )["data"]
+        return workload
+    def _cancel_workload(self, workload_id: str) -> Dict[str, Any]:
+        workload: Dict[str, Any] = self._request(
+            "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"
+        )["data"]
+        return workload
+
     def get_device_specs_dict(self) -> Dict[str, str]:
         device_specs: Dict[str, str] = self._request(
             "GET", f"{self.endpoints.core}/api/v1/devices/specs"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -173,6 +173,7 @@ class Client:
             "GET", f"{self.endpoints.core}/api/v1/workloads/{workload_id}"
         )["data"]
         return workload
+
     def _cancel_workload(self, workload_id: str) -> Dict[str, Any]:
         workload: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pydantic import BaseModel
 from pasqal_cloud.client import Client
 from typing import List,Dict,Any

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -12,13 +12,15 @@ class Workload(BaseModel):
 
     Attributes:
         - id: Unique identifier for the workload.
-        - project_id: ID of the project which the users scheduling the workload belong to.
+        - project_id: ID of the project which the users scheduling the workload
+         belong to.
         - status: Status of the workload. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
         - _client: A Client instance to connect to PCS.
         - backend: The backend used for the workload.
         - workload_type: The type of the workload.
-        - config: The config containing all the necessary information for the workload to run.
+        - config: The config containing all the necessary information for
+         the workload to run.
         - created_at: Timestamp of the creation of the workload.
         - updated_at: Timestamp of the last update of the workload.
         - errors: Error messages that occurred while processing workload.
@@ -31,9 +33,9 @@ class Workload(BaseModel):
     project_id: str
     status: str
     _client: Client
-    backend: Optional[str] = None
-    workload_type: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
+    backend: str
+    workload_type: str
+    config: Dict[str, Any]
     created_at: str
     updated_at: str
     errors: Optional[List[str]] = None

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -1,26 +1,31 @@
 from __future__ import annotations
-from pydantic import BaseModel
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Extra
+
 from pasqal_cloud.client import Client
-from typing import List,Dict,Any,Optional
-class Workload(BaseModel) :
+
+
+class Workload(BaseModel):
     """Class for workload data.
 
-        Attributes:
-            - id: Unique identifier for the workload.
-            - project_id: ID of the project which the users scheduling the workload belong to.
-            - status: Status of the workload. Possible values are:
-                PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
-            - _client: A Client instance to connect to PCS.
-            - backend: The backend used for the workload.
-            - workload_type: The type of the workload.
-            - config: The config containing all the necessary information for the workload to run.
-            - created_at: Timestamp of the creation of the workload.
-            - updated_at: Timestamp of the last update of the workload.
-            - errors: Error messages that occurred while processing workload.
-            - start_timestamp: The timestamp of when the workload began processing.
-            - end_timestamp: The timestamp of when the workload finished processing.
-            - result: Result of the workload.
-        """
+    Attributes:
+        - id: Unique identifier for the workload.
+        - project_id: ID of the project which the users scheduling the workload belong to.
+        - status: Status of the workload. Possible values are:
+            PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
+        - _client: A Client instance to connect to PCS.
+        - backend: The backend used for the workload.
+        - workload_type: The type of the workload.
+        - config: The config containing all the necessary information for the workload to run.
+        - created_at: Timestamp of the creation of the workload.
+        - updated_at: Timestamp of the last update of the workload.
+        - errors: Error messages that occurred while processing workload.
+        - start_timestamp: The timestamp of when the workload began processing.
+        - end_timestamp: The timestamp of when the workload finished processing.
+        - result: Result of the workload.
+    """
 
     id: str
     project_id: str
@@ -35,3 +40,13 @@ class Workload(BaseModel) :
     start_timestamp: Optional[str] = None
     end_timestamp: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = Extra.allow
+        arbitrary_types_allowed = True
+
+    def cancel(self) -> Dict[str, Any]:
+        """Cancel the current job on the PCS."""
+        workload_rsp = self._client._cancel_workload(self.id)
+        self.status = workload_rsp.get("status", "CANCELED")
+        return workload_rsp

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from pasqal_cloud.client import Client
-from typing import List,Dict,Any
+from typing import List,Dict,Any,Optional
 class Workload(BaseModel) :
     """Class for workload data.
 
@@ -26,12 +26,12 @@ class Workload(BaseModel) :
     project_id: str
     status: str
     _client: Client
-    backend: str | None = None
-    workload_type: str | None = None
-    config: Dict[str, Any] | None = None
+    backend: Optional[str] = None
+    workload_type: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
     created_at: str
     updated_at: str
-    errors: List[str] = None
-    start_timestamp: str | None = None
-    end_timestamp: str | None = None
-    result: Dict[str, Any] | None = None
+    errors: Optional[List[str]] = None
+    start_timestamp: Optional[str] = None
+    end_timestamp: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+from pasqal_cloud.client import Client
+from typing import List,Dict,Any
+class Workload(BaseModel) :
+    """Class for workload data.
+
+        Attributes:
+            - id: Unique identifier for the workload.
+            - project_id: ID of the project which the users scheduling the workload belong to.
+            - status: Status of the workload. Possible values are:
+                PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
+            - _client: A Client instance to connect to PCS.
+            - backend: The backend used for the workload.
+            - workload_type: The type of the workload.
+            - config: The config containing all the necessary information for the workload to run.
+            - created_at: Timestamp of the creation of the workload.
+            - updated_at: Timestamp of the last update of the workload.
+            - errors: Error messages that occurred while processing workload.
+            - start_timestamp: The timestamp of when the workload began processing.
+            - end_timestamp: The timestamp of when the workload finished processing.
+            - result: Result of the workload.
+        """
+
+    id: str
+    project_id: str
+    status: str
+    _client: Client
+    backend: str | None = None
+    workload_type: str | None = None
+    config: Dict[str, Any] | None = None
+    created_at: str
+    updated_at: str
+    errors: List[str] = None
+    start_timestamp: str | None = None
+    end_timestamp: str | None = None
+    result: Dict[str, Any] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import requests_mock
 
-from pasqal_cloud import Batch, Client, Job
+from pasqal_cloud import Batch, Client, Job, Workload
 from pasqal_cloud.endpoints import Endpoints
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
@@ -64,6 +64,23 @@ def pasqal_client_mock():
         password="password",
     )
     return client
+
+
+@pytest.fixture
+def workload(pasqal_client_mock):
+    workload_data = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "project_id": "00000000-0000-0000-0000-000000000001",
+        "status": "PENDING",
+        "_client": pasqal_client_mock,
+        "created_at": "2022-12-31T23:59:59.999Z",
+        "updated_at": "2023-01-01T00:00:00.000Z",
+        "errors": [],
+        "backend": "backend_test",
+        "workload_type": "workload_type_test",
+        "config": {"test1": "test1", "test2": 2},
+    }
+    return Workload(**workload_data)
 
 
 @pytest.fixture

--- a/tests/fixtures/api/workloads/00000000-0000-0000-0000-000000000001/_.GET.json
+++ b/tests/fixtures/api/workloads/00000000-0000-0000-0000-000000000001/_.GET.json
@@ -1,0 +1,22 @@
+{
+  "code": 200,
+  "data":
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "project_id": "00000000-0000-0000-0000-000000000002",
+      "created_at": "2021-11-10T15:24:38.172109",
+      "errors": [],
+      "result": { "1001": 12, "0110": 35, "1111": 1 },
+      "backend": "backend_test",
+      "workload_type": "workload_type_test",
+      "config": {"test1": "test1", "test2": 2},
+      "status": "DONE",
+      "updated_at": "2021-11-10T15:27:06.698066",
+      "start_timestamp": "21636558026.698066",
+      "end_timestamp": "1636558026.698066"
+
+    }
+  ,
+  "message": "OK.",
+  "status": "success"
+}

--- a/tests/fixtures/api/workloads/00000000-0000-0000-0000-000000000001/cancel/_.PUT.json
+++ b/tests/fixtures/api/workloads/00000000-0000-0000-0000-000000000001/cancel/_.PUT.json
@@ -1,0 +1,20 @@
+{
+    "status": "success",
+    "message": "OK.",
+    "code": "200",
+    "data": {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "created_at": "2023-03-24T09:05:32.420887+00:00",
+        "updated_at": "2023-03-24T09:06:52.105568+00:00",
+        "start_timestamp": null,
+        "end_timestamp": "2023-03-24T09:06:52.107659+00:00",
+        "backend": "backend_test",
+        "workload_type": "workload_type_test",
+        "config": {"test1": "test1", "test2": 2},
+        "status": "CANCELED",
+        "result": null,
+        "errors": null,
+        "variables": {},
+        "project_id": "00000000-0000-0000-0000-000000000002"
+    }
+}

--- a/tests/fixtures/api/workloads/_.POST.json
+++ b/tests/fixtures/api/workloads/_.POST.json
@@ -1,0 +1,20 @@
+{
+  "code": 200,
+  "data": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "project_id": "00000000-0000-0000-0000-000000000002",
+    "created_at": "2021-11-10T15:24:38.172109",
+    "errors": [
+    ],
+    "result": null,
+    "backend": "backend_test",
+    "workload_type": "workload_type_test",
+    "config": {"test1": "test1", "test2": 2},
+    "status": "PENDING",
+    "updated_at": "2021-11-10T15:27:06.698066",
+    "start_timestamp": "1636558026.698066",
+    "end_timestamp": "1636558026.698066"
+  },
+  "message": "OK.",
+  "status": "success"
+}

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from pasqal_cloud import SDK, Workload
+from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
+
+
+class TestWorkload:
+    @pytest.fixture(autouse=True)
+    @patch(
+        "pasqal_cloud.client.Auth0TokenProvider",
+        FakeAuth0AuthenticationSuccess,
+    )
+    def init_sdk(self, start_mock_request):
+        self.sdk = SDK(
+            username="me@test.com",
+            password="password",
+            project_id=str(uuid4()),
+        )
+        self.workload_id = "00000000-0000-0000-0000-000000000001"
+        self.backend = "backend_test"
+        self.workload_type = "workload_type_test"
+        self.config = {"test1": "test1", "test2": 2}
+        self.workload_result = {"1001": 12, "0110": 35, "1111": 1}
+
+    def test_create_workload(self):
+        workload = self.sdk.create_workload(
+            backend=self.backend,
+            workload_type=self.workload_type,
+            config=self.config,
+        )
+        assert workload.id == self.workload_id
+        assert workload.backend == self.backend
+        assert workload.workload_type == self.workload_type
+        assert workload.config == self.config
+
+    def test_create_workload_and_wait(self, request_mock):
+        workload = self.sdk.create_workload(
+            backend=self.backend,
+            workload_type=self.workload_type,
+            config=self.config,
+            wait=True,
+        )
+        assert workload.id == self.workload_id
+        assert workload.backend == self.backend
+        assert workload.workload_type == self.workload_type
+        assert workload.config == self.config
+        assert workload.result == self.workload_result
+        assert request_mock.last_request.method == "GET"
+
+    def test_get_workload(self, request_mock, workload):
+        workload_requested = self.sdk.get_workload(workload.id)
+        assert workload_requested.id == self.workload_id
+        assert (
+            request_mock.last_request.url == f"{self.sdk._client.endpoints.core}"
+            f"/api/v1/workloads/{self.workload_id}"
+        )
+
+    def test_cancel_workload_self(self, request_mock, workload):
+        workload.cancel()
+        assert workload.status == "CANCELED"
+        assert request_mock.last_request.method == "PUT"
+        assert (
+            request_mock.last_request.url == f"{self.sdk._client.endpoints.core}"
+            f"/api/v1/workloads/{self.workload_id}/cancel"
+        )
+
+    def test_cancel_workload_sdk(self, request_mock, workload):
+        client_rsp = self.sdk.cancel_workload(self.workload_id)
+        assert type(client_rsp) == Workload
+        assert client_rsp.status == "CANCELED"
+        assert request_mock.last_request.method == "PUT"
+        assert (
+            request_mock.last_request.url == f"{self.sdk._client.endpoints.core}"
+            f"/api/v1/workloads/{self.workload_id}/cancel"
+        )
+
+    def test_workload_instantiation_with_extra_field(self, workload):
+        """Instantiating a workload with an extra field should not raise an error.
+
+        This enables us to add new fields in the API response on the workloads endpoint
+        without breaking compatibility for users with old versions of the SDK where
+        the field is not present in the Batch class.
+        """
+        workload_dict = workload.dict()  # Batch data expected by the SDK
+        # We add an extra field to mimick the API exposing new values to the user
+        workload_dict["new_field"] = "any_value"
+
+        new_workload = Workload(**workload_dict)  # this should raise no error
+        assert (
+            new_workload.new_field == "any_value"
+        )  # The new value should be stored regardless


### PR DESCRIPTION
This MR enables to use workloads through the SDK by using the create_workload, get_workload and cancel_workload methods which are hitting the corresponding endpoints in Core API. Unit tests and necessary fixtures were also added for that.