### PR TITLE
[FEAT] Batch's jobs are now returned in the same order they were created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to this project will be documented in this file.
 
 
-
 ## [0.3.5] - 2023-07-21
 
 ### Added
@@ -13,7 +12,6 @@ Added an `ordered_jobs` list as an attribute to the `Batch` object in which jobs
 ### Changed
 
 Batch attribute `jobs` is now deprecated, use `ordered_jobs` instead.
-
 
 ## [0.3.4] - 2023-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-Now jobs are ordered by creation date in a list through the attribute `ordered_jobs` when manipulating a Batch object.
+Added an `ordered_jobs` list as an attribute to the `Batch` object in which jobs are ordered by creation date.
+
+### Changed
+
+Batch attribute `jobs` is now deprecated, use `ordered_jobs` instead.
 
 
 ## [0.3.4] - 2023-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+
+
+## [0.3.5] - 2023-07-21
+
+### Added
+
+Now jobs are ordered by creation date in a list through the attribute `ordered_jobs` when manipulating a Batch object.
+
+
 ## [0.3.4] - 2023-07-18
 
 ### Added

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -164,8 +164,9 @@ class Batch(BaseModel):
                     self.id,
                 )
 
-            jobs = [Job(**job, _client=self._client) for job in batch_rsp["jobs"]]
-            self.ordered_jobs = jobs
+            self.ordered_jobs = [
+                Job(**job, _client=self._client) for job in batch_rsp["jobs"]
+            ]
 
         return batch_rsp
 

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -1,6 +1,5 @@
 import time
 from typing import Any, Dict, List, Optional, Type, Union
-from warnings import warn
 
 from pydantic import BaseModel, Extra, root_validator, validator
 
@@ -71,13 +70,13 @@ class Batch(BaseModel):
         extra = Extra.allow
         arbitrary_types_allowed = True
 
-    def __getattribute__(self, jobs):
-        warn(
-            "'jobs' attribute is deprecated, use 'ordered_jobs' instead",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        return super().__getattribute__(jobs)
+    # def __getattribute__(self, jobs):
+    #     warn(
+    #         "'jobs' attribute is deprecated, use 'ordered_jobs' instead",
+    #         DeprecationWarning,
+    #         stacklevel=1,
+    #     )
+    #     return super().__getattribute__(jobs)
 
     @validator("configuration", pre=True)
     def _load_configuration(

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -69,19 +69,10 @@ class Batch(BaseModel):
         extra = Extra.allow
         arbitrary_types_allowed = True
 
-    @property
-    def jobs(self) -> dict[str, Job]:
-        warn(
-            "'jobs' attribute is deprecated, use 'ordered_jobs' instead",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        return {**{job.id: job for job in self.ordered_jobs}}
-
     @root_validator(pre=True)
     def _build_ordered_jobs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """This root validator will modify the 'jobs' attribute (which is a list
-        of jobs dictionaries ordered by creation time before instantiation).
+        """This root validator will modify the 'jobs' attribute which is a list
+        of jobs dictionaries ordered by creation time before instantiation.
         It will duplicate the value of 'jobs' in a new attribute 'ordered_jobs'
         to keep the jobs ordered by creation time.
         """
@@ -95,6 +86,18 @@ class Batch(BaseModel):
 
         values["ordered_jobs"] = ordered_jobs_list
         return values
+
+    @property
+    def jobs(self) -> dict[str, Job]:
+        """Once the 'ordered_jobs' is build, we need to keep the 'jobs' attribute
+        for backward compatibility with the code written by the users of the sdk
+        """
+        warn(
+            "'jobs' attribute is deprecated, use 'ordered_jobs' instead",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        return {**{job.id: job for job in self.ordered_jobs}}
 
     @validator("configuration", pre=True)
     def _load_configuration(

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -59,6 +59,7 @@ class Batch(BaseModel):
     start_datetime: Optional[str]
     end_datetime: Optional[str]
     device_status: Optional[str]
+    # Ticket TBD
     jobs: Dict[str, Job] = {}
     ordered_jobs: List[Job] = []
     jobs_count: int = 0
@@ -83,6 +84,8 @@ class Batch(BaseModel):
         elif values["device_type"] == EmulatorType.EMU_FREE.value:
             conf_class = EmuFreeConfig
         return conf_class.from_dict(configuration)
+
+    # TODO  Create a way to raise a warning while accessing 'jobs' attribute
 
     @root_validator(pre=True)
     def _build_job_dict_and_list(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -164,11 +164,8 @@ class Batch(BaseModel):
                     self.id,
                 )
 
-            jobs_list = []
-            for job_data in batch_rsp["jobs"]:
-                job = Job(**job_data, _client=self._client)
-                jobs_list.append(job)
-            self.ordered_jobs = jobs_list
+            jobs = [Job(**job, _client=self._client) for job in batch_rsp["jobs"]]
+            self.ordered_jobs = jobs
 
         return batch_rsp
 

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -87,9 +87,10 @@ class Batch(BaseModel):
         values["ordered_jobs"] = ordered_jobs_list
         return values
 
+    # Ticket (#704), to be removed or updated
     @property
     def jobs(self) -> Dict[str, Job]:
-        """Once the 'ordered_jobs' is build, we need to keep the 'jobs' attribute
+        """Once the 'ordered_jobs' is built, we need to keep the 'jobs' attribute
         for backward compatibility with the code written by the users of the sdk
         """
         warn(

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -79,7 +79,7 @@ class Batch(BaseModel):
         return {**{job.id: job for job in self.ordered_jobs}}
 
     @root_validator(pre=True)
-    def _build_job_dict_and_list(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def _build_ordered_jobs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """This root validator will modify the 'jobs' attribute (which is a list
         of jobs dictionaries ordered by creation time before instantiation).
         It will duplicate the value of 'jobs' in a new attribute 'ordered_jobs'

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -77,13 +77,10 @@ class Batch(BaseModel):
         to keep the jobs ordered by creation time.
         """
         ordered_jobs_list = []
-
         jobs_received = values.get("jobs", [])
-
         for job in jobs_received:
             job_dict = {**job, "_client": values["_client"]}
             ordered_jobs_list.append(job_dict)
-
         values["ordered_jobs"] = ordered_jobs_list
         return values
 

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -60,7 +60,7 @@ class Batch(BaseModel):
     start_datetime: Optional[str]
     end_datetime: Optional[str]
     device_status: Optional[str]
-    ordered_jobs: List[Job]
+    ordered_jobs: List[Job] = []
     jobs_count: int = 0
     jobs_count_per_status: Dict[str, int] = {}
     configuration: Union[BaseConfig, Dict[str, Any], None] = None
@@ -88,7 +88,7 @@ class Batch(BaseModel):
         return values
 
     @property
-    def jobs(self) -> dict[str, Job]:
+    def jobs(self) -> Dict[str, Job]:
         """Once the 'ordered_jobs' is build, we need to keep the 'jobs' attribute
         for backward compatibility with the code written by the users of the sdk
         """

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -136,7 +136,6 @@ class Batch(BaseModel):
         job_rsp = self._client._send_job(job_data)
         job = Job(**job_rsp, _client=self._client)
         self.ordered_jobs.append(job)
-        self.jobs[job.id] = job
         if wait:
             while job.status in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
@@ -167,7 +166,7 @@ class Batch(BaseModel):
                     self.id,
                 )
             for job_rsp in batch_rsp["jobs"]:
-                job_rsp_obj = Job(**job_rsp)
+                job_rsp_obj = Job(**job_rsp, _client=self._client)
                 # iterate through the ordered_job list attribute of Batch and find the
                 # index of the job received in the response to replace with updated data
                 job_index = [
@@ -175,7 +174,6 @@ class Batch(BaseModel):
                 ].index(True)
 
                 self.ordered_jobs[job_index] = job_rsp_obj
-                self.jobs[job_rsp["id"]] = job_rsp_obj
 
         return batch_rsp
 

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -163,7 +163,6 @@ class Batch(BaseModel):
                 batch_rsp = self._client._get_batch(
                     self.id,
                 )
-
             self.ordered_jobs = [
                 Job(**job, _client=self._client) for job in batch_rsp["jobs"]
             ]

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -1,5 +1,6 @@
 import time
 from typing import Any, Dict, List, Optional, Type, Union
+from warnings import warn
 
 from pydantic import BaseModel, Extra, root_validator, validator
 
@@ -70,6 +71,14 @@ class Batch(BaseModel):
         extra = Extra.allow
         arbitrary_types_allowed = True
 
+    def __getattribute__(self, jobs):
+        warn(
+            "'jobs' attribute is deprecated, use 'ordered_jobs' instead",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        return super().__getattribute__(jobs)
+
     @validator("configuration", pre=True)
     def _load_configuration(
         cls,
@@ -84,8 +93,6 @@ class Batch(BaseModel):
         elif values["device_type"] == EmulatorType.EMU_FREE.value:
             conf_class = EmuFreeConfig
         return conf_class.from_dict(configuration)
-
-    # TODO  Create a way to raise a warning while accessing 'jobs' attribute
 
     @root_validator(pre=True)
     def _build_job_dict_and_list(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -97,7 +97,7 @@ class Batch(BaseModel):
             DeprecationWarning,
             stacklevel=1,
         )
-        return {**{job.id: job for job in self.ordered_jobs}}
+        return {job.id: job for job in self.ordered_jobs}
 
     @validator("configuration", pre=True)
     def _load_configuration(

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -165,15 +165,12 @@ class Batch(BaseModel):
                 batch_rsp = self._client._get_batch(
                     self.id,
                 )
-            for job_rsp in batch_rsp["jobs"]:
-                job_rsp_obj = Job(**job_rsp, _client=self._client)
-                # iterate through the ordered_job list attribute of Batch and find the
-                # index of the job received in the response to replace with updated data
-                job_index = [
-                    job_rsp_obj.id == job.id for job in self.ordered_jobs
-                ].index(True)
 
-                self.ordered_jobs[job_index] = job_rsp_obj
+            jobs_list = []
+            for job_data in batch_rsp["jobs"]:
+                job = Job(**job_data, _client=self._client)
+                jobs_list.append(job)
+            self.ordered_jobs = jobs_list
 
         return batch_rsp
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -55,9 +55,6 @@ class TestBatch:
         "ignore:Argument `fetch_results` is deprecated and will be removed "
         "in a future version. Please use argument `wait` instead"
     )
-    @pytest.mark.filterwarnings(
-        "ignore:'jobs' attribute is deprecated, use 'ordered_jobs' instead"
-    )
     @pytest.mark.parametrize("wait,fetch_results", [(True, False), (False, True)])
     def test_create_batch_and_wait(self, request_mock, wait, fetch_results):
         job = {
@@ -79,11 +76,14 @@ class TestBatch:
         assert batch.ordered_jobs[0].id == self.job_id
         assert batch.ordered_jobs[0].result == self.job_result
         assert batch.ordered_jobs[0].full_result == self.job_full_result
-        # attribute 'jobs' to be removed
-        for job_id, job in batch.jobs.items():
-            assert self.job_id == job_id
-            assert job.result == self.job_result
-            assert job.full_result == self.job_full_result
+        with pytest.warns(
+            DeprecationWarning,
+            match="'jobs' attribute is deprecated, use 'ordered_jobs' instead",
+        ):
+            for job_id, job in batch.jobs.items():
+                assert self.job_id == job_id
+                assert job.result == self.job_result
+                assert job.full_result == self.job_full_result
         assert request_mock.last_request.method == "GET"
 
     def test_get_batch(self, batch):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -59,7 +59,7 @@ class TestBatch:
     def test_create_batch_and_wait(self, request_mock, wait, fetch_results):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
-            jobs=[self.simple_job_args, self.simple_job_args],
+            jobs=[self.simple_job_args],
             wait=wait,
             fetch_results=fetch_results,
         )
@@ -100,12 +100,6 @@ class TestBatch:
         assert job.batch_id == batch.id
         assert job.runs == self.n_job_runs
         assert len(batch.ordered_jobs) == 2
-        # Ticket (#704)
-        with pytest.warns(
-            DeprecationWarning,
-            match="'jobs' attribute is deprecated, use 'ordered_jobs' instead",
-        ):
-            assert len(batch.jobs) == 2
 
     def test_batch_add_job_and_wait_for_results(self, request_mock):
         batch = self.sdk.create_batch(
@@ -140,7 +134,7 @@ class TestBatch:
     def test_batch_declare_complete_and_wait_for_results(self, request_mock):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
-            jobs=[self.simple_job_args, self.simple_job_args],
+            jobs=[self.simple_job_args],
         )
         rsp = batch.declare_complete(wait=True)
         assert rsp["complete"]
@@ -152,13 +146,7 @@ class TestBatch:
         assert batch.ordered_jobs[0].batch_id == batch.id
         assert batch.ordered_jobs[0].result == self.job_result
         assert batch.ordered_jobs[0].full_result == self.job_full_result
-        assert len(batch.ordered_jobs) == 2
-        # Ticket (#704)
-        with pytest.warns(
-            DeprecationWarning,
-            match="'jobs' attribute is deprecated, use 'ordered_jobs' instead",
-        ):
-            assert len(batch.jobs) == 2
+        assert len(batch.ordered_jobs) == 1
 
     def test_cancel_batch_self(self, request_mock, batch):
         batch.cancel()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -85,30 +85,25 @@ class TestBatch:
                 assert self.job_id == job_id
                 assert job.result == self.job_result
                 assert job.full_result == self.job_full_result
+            assert len(batch.jobs) == len(batch.ordered_jobs)
         assert request_mock.last_request.method == "GET"
 
     def test_get_batch(self, batch):
         batch_requested = self.sdk.get_batch(batch.id)
         assert batch_requested.id == self.batch_id
 
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_add_job(self, request_mock):
-        job = {
-            "runs": self.n_job_runs,
-            "variables": self.job_variables,
-        }
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
-            jobs=[job],
         )
-        assert len(batch.ordered_jobs) == 1
-        assert len(batch.jobs) == 1
         job = batch.add_job(
             runs=self.n_job_runs,
             variables=self.job_variables,
         )
         assert request_mock.last_request.json()["batch_id"] == batch.id
         assert job.batch_id == batch.id
-        assert len(batch.jobs) == 2
+        assert job.runs == self.n_job_runs
 
     @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_add_job_and_wait_for_results(self, request_mock):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -101,7 +101,11 @@ class TestBatch:
         assert job.runs == self.n_job_runs
         assert len(batch.ordered_jobs) == 2
         # Ticket (#704)
-        assert len(batch.jobs) == 2
+        with pytest.warns(
+            DeprecationWarning,
+            match="'jobs' attribute is deprecated, use 'ordered_jobs' instead",
+        ):
+            assert len(batch.jobs) == 2
 
     def test_batch_add_job_and_wait_for_results(self, request_mock):
         batch = self.sdk.create_batch(
@@ -150,7 +154,11 @@ class TestBatch:
         assert batch.ordered_jobs[0].full_result == self.job_full_result
         assert len(batch.ordered_jobs) == 2
         # Ticket (#704)
-        assert len(batch.jobs) == 2
+        with pytest.warns(
+            DeprecationWarning,
+            match="'jobs' attribute is deprecated, use 'ordered_jobs' instead",
+        ):
+            assert len(batch.jobs) == 2
 
     def test_cancel_batch_self(self, request_mock, batch):
         batch.cancel()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -93,7 +93,7 @@ class TestBatch:
             serialized_sequence=self.pulser_sequence, jobs=[self.simple_job_args]
         )
         job = batch.add_job(
-            runs=78,
+            runs=self.n_job_runs,
             variables=self.job_variables,
         )
         assert request_mock.last_request.json()["batch_id"] == batch.id

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -93,7 +93,7 @@ class TestBatch:
             serialized_sequence=self.pulser_sequence, jobs=[self.simple_job_args]
         )
         job = batch.add_job(
-            runs=self.n_job_runs,
+            runs=78,
             variables=self.job_variables,
         )
         assert request_mock.last_request.json()["batch_id"] == batch.id

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -76,6 +76,7 @@ class TestBatch:
         assert batch.ordered_jobs[0].id == self.job_id
         assert batch.ordered_jobs[0].result == self.job_result
         assert batch.ordered_jobs[0].full_result == self.job_full_result
+        # Ticket (#704)
         with pytest.warns(
             DeprecationWarning,
             match="'jobs' attribute is deprecated, use 'ordered_jobs' instead",
@@ -89,6 +90,68 @@ class TestBatch:
     def test_get_batch(self, batch):
         batch_requested = self.sdk.get_batch(batch.id)
         assert batch_requested.id == self.batch_id
+
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
+    def test_batch_add_job(self, request_mock):
+        batch = self.sdk.create_batch(
+            serialized_sequence=self.pulser_sequence,
+        )
+        job = batch.add_job(
+            runs=self.n_job_runs,
+            variables=self.job_variables,
+        )
+        assert request_mock.last_request.json()["batch_id"] == batch.id
+        assert job.batch_id == batch.id
+        assert job.runs == self.n_job_runs
+
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
+    def test_batch_add_job_and_wait_for_results(self, request_mock):
+        batch = self.sdk.create_batch(
+            serialized_sequence=self.pulser_sequence,
+        )
+        job = batch.add_job(
+            runs=self.n_job_runs,
+            variables={
+                "Omega_max": 14.4,
+                "last_target": "q1",
+                "ts": [200, 500],
+            },
+            wait=True,
+        )
+        assert job.batch_id == batch.id
+        assert job.runs == self.n_job_runs
+        assert request_mock.last_request.method == "GET"
+        assert (
+            request_mock.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}"
+        )
+        assert job.result == self.job_result
+        assert job.full_result == self.job_full_result
+
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
+    def test_batch_declare_complete(self):
+        batch = self.sdk.create_batch(
+            serialized_sequence=self.pulser_sequence,
+        )
+        rsp = batch.declare_complete(wait=False)
+        assert rsp["complete"]
+        assert len(batch.jobs) == 0
+
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
+    def test_batch_declare_complete_and_wait_for_results(self, request_mock):
+        batch = self.sdk.create_batch(
+            serialized_sequence=self.pulser_sequence,
+        )
+        rsp = batch.declare_complete(wait=True)
+        assert rsp["complete"]
+        assert request_mock.last_request.method == "GET"
+        assert (
+            request_mock.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}"
+        )
+        assert batch.jobs[self.job_id].batch_id == batch.id
+        assert batch.jobs[self.job_id].result == self.job_result
+        assert batch.jobs[self.job_id].full_result == self.job_full_result
 
     def test_cancel_batch_self(self, request_mock, batch):
         batch.cancel()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -55,6 +55,9 @@ class TestBatch:
         "ignore:Argument `fetch_results` is deprecated and will be removed "
         "in a future version. Please use argument `wait` instead"
     )
+    @pytest.mark.filterwarnings(
+        "ignore:'jobs' attribute is deprecated, use 'ordered_jobs' instead"
+    )
     @pytest.mark.parametrize("wait,fetch_results", [(True, False), (False, True)])
     def test_create_batch_and_wait(self, request_mock, wait, fetch_results):
         job = {

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -76,6 +76,11 @@ class TestBatch:
         assert batch.ordered_jobs[0].id == self.job_id
         assert batch.ordered_jobs[0].result == self.job_result
         assert batch.ordered_jobs[0].full_result == self.job_full_result
+        # attribute 'jobs' to be removed
+        for job_id, job in batch.jobs.items():
+            assert self.job_id == job_id
+            assert job.result == self.job_result
+            assert job.full_result == self.job_full_result
         assert request_mock.last_request.method == "GET"
 
     def test_get_batch(self, batch):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -135,7 +135,8 @@ class TestBatch:
 
     def test_batch_declare_complete_and_wait_for_results(self, request_mock):
         batch = self.sdk.create_batch(
-            serialized_sequence=self.pulser_sequence, jobs=[self.simple_job_args]
+            serialized_sequence=self.pulser_sequence,
+            jobs=[self.simple_job_args, self.simple_job_args],
         )
         rsp = batch.declare_complete(wait=True)
         assert rsp["complete"]
@@ -147,6 +148,9 @@ class TestBatch:
         assert batch.ordered_jobs[0].batch_id == batch.id
         assert batch.ordered_jobs[0].result == self.job_result
         assert batch.ordered_jobs[0].full_result == self.job_full_result
+        assert len(batch.ordered_jobs) == 2
+        # Ticket (#704)
+        assert len(batch.jobs) == 2
 
     def test_cancel_batch_self(self, request_mock, batch):
         batch.cancel()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -142,11 +142,11 @@ class TestBatch:
         assert request_mock.last_request.method == "GET"
         assert (
             request_mock.last_request.url
-            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}"
+            == f"{self.sdk._client.endpoints.core}/api/v1/batches/{self.batch_id}"
         )
-        assert batch.jobs[self.job_id].batch_id == batch.id
-        assert batch.jobs[self.job_id].result == self.job_result
-        assert batch.jobs[self.job_id].full_result == self.job_full_result
+        assert batch.ordered_jobs[0].batch_id == batch.id
+        assert batch.ordered_jobs[0].result == self.job_result
+        assert batch.ordered_jobs[0].full_result == self.job_full_result
 
     def test_cancel_batch_self(self, request_mock, batch):
         batch.cancel()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -91,18 +91,24 @@ class TestBatch:
         batch_requested = self.sdk.get_batch(batch.id)
         assert batch_requested.id == self.batch_id
 
-    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_add_job(self, request_mock):
+        job = {
+            "runs": self.n_job_runs,
+            "variables": self.job_variables,
+        }
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
+            jobs=[job],
         )
+        assert len(batch.ordered_jobs) == 1
+        assert len(batch.jobs) == 1
         job = batch.add_job(
             runs=self.n_job_runs,
             variables=self.job_variables,
         )
         assert request_mock.last_request.json()["batch_id"] == batch.id
         assert job.batch_id == batch.id
-        assert job.runs == self.n_job_runs
+        assert len(batch.jobs) == 2
 
     @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_add_job_and_wait_for_results(self, request_mock):


### PR DESCRIPTION
This MR is following changes in the APIs, from now the jobs of a Batch are returned in order of insertion in the DB.

What does this MR:
- Introduce a new Batch Attribute called 'ordered_jobs which is a list of Jobs, it is basically filled with jobs data returned by the APIs without any additional transformation
- Make Batch 'jobs' attribute deprecated
- Update current tests
- Skipped Iroise tests are now operational 