### PR TITLE
[FIX] Add always=True to result validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3] - 2024-12-08
+
+### Added
+
+- CRUCIAL BUGFIX - added `always=True` to result validator to download results from link
+- Added exception case for results download
+
 ## [0.4.2] - 2023-10-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- CRUCIAL BUGFIX - added `always=True` to result validator to download results from link
+- CRUCIAL BUGFIX - download results properly from result link
 - Added exception case for results download
 
 ## [0.4.2] - 2023-10-09

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/pasqal_cloud/errors.py
+++ b/pasqal_cloud/errors.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional
 
-from requests import HTTPError, Response
+from requests import ConnectionError, HTTPError, Response
 
 
 class ExceptionWithResponseContext(BaseException):
@@ -140,6 +140,16 @@ class WorkloadResultsDownloadError(WorkloadException):
 
     def __init__(self, e: HTTPError) -> None:
         super().__init__("Workload results download failed.", e)
+
+
+class WorkloadResultsConnectionError(BaseException):
+    """
+    Exception class raised when failed to download results
+    for a connection error.
+    """
+
+    def __init__(self, e: ConnectionError) -> None:
+        super().__init__("Workload results download failed from connection error.", e)
 
 
 class WorkloadResultsDecodeError(WorkloadException):

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -65,7 +65,7 @@ class Workload(BaseModel):
         self.status = workload_rsp.get("status", "CANCELED")
         return workload_rsp
 
-    @validator("result")
+    @validator("result", always=True)
     def result_link_to_result(
         cls, result: Optional[Dict[str, Any]], values: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -10,6 +10,7 @@ from pasqal_cloud.client import Client
 from pasqal_cloud.errors import (
     InvalidWorkloadResultsFormatError,
     WorkloadCancellingError,
+    WorkloadResultsConnectionError,
     WorkloadResultsDecodeError,
     WorkloadResultsDownloadError,
 )
@@ -76,6 +77,8 @@ class Workload(BaseModel):
             res = requests.get(result_link)
         except HTTPError as e:
             raise WorkloadResultsDownloadError(e) from e
+        except requests.ConnectionError as e:
+            raise WorkloadResultsConnectionError(e) from e
         try:
             data = res.json()
         except Exception as e:

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -180,6 +180,9 @@ class TestWorkload:
         )  # The new value should be stored regardless
 
     def test_workload_result_raise_connection_error(self, workload):
+        """
+        Check that error is raised when improper url is set.
+        """
         workload_dict = workload.dict()
         workload_dict.pop("result")
         workload_dict["result_link"] = "http://test.test"
@@ -187,6 +190,9 @@ class TestWorkload:
             Workload(**workload_dict)
 
     def tests_workload_result_set(self, workload):
+        """
+        Check that result is set when only result_link is provided.
+        """
         workload_dict = workload.dict()
         workload_dict.pop("result")
         workload_dict["result_link"] = "http://test.test"

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -8,6 +8,7 @@ from pasqal_cloud.errors import (
     WorkloadCancellingError,
     WorkloadCreationError,
     WorkloadFetchingError,
+    WorkloadResultsConnectionError,
     WorkloadResultsDecodeError,
 )
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -175,3 +176,11 @@ class TestWorkload:
         assert (
             new_workload.new_field == "any_value"
         )  # The new value should be stored regardless
+
+    @pytest.mark.only
+    def test_workload_result_set_when_no_result(self, workload):
+        workload_dict = workload.dict()
+        workload_dict.pop("result")
+        workload_dict["result_link"] = "http://test.test"
+        with pytest.raises(WorkloadResultsConnectionError):
+            Workload(**workload_dict)

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -177,7 +177,6 @@ class TestWorkload:
             new_workload.new_field == "any_value"
         )  # The new value should be stored regardless
 
-    @pytest.mark.only
     def test_workload_result_set_when_no_result(self, workload):
         workload_dict = workload.dict()
         workload_dict.pop("result")

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,3 +1,5 @@
+import json
+import requests
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
@@ -177,9 +179,20 @@ class TestWorkload:
             new_workload.new_field == "any_value"
         )  # The new value should be stored regardless
 
-    def test_workload_result_set_when_no_result(self, workload):
+    def test_workload_result_raise_connection_error(self, workload):
         workload_dict = workload.dict()
         workload_dict.pop("result")
         workload_dict["result_link"] = "http://test.test"
         with pytest.raises(WorkloadResultsConnectionError):
             Workload(**workload_dict)
+
+    @pytest.mark.only
+    def tests_workload_result_set(self, workload):
+        workload_dict = workload.dict()
+        workload_dict.pop("result")
+        workload_dict["result_link"] = "http://test.test"
+        resp = requests.Response()
+        resp._content = json.dumps({"some": "data"}).encode("utf-8")
+        with patch("requests.get", lambda x: resp):
+            res = Workload(**workload_dict)
+        assert res.result == {"some": "data"}

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -186,7 +186,6 @@ class TestWorkload:
         with pytest.raises(WorkloadResultsConnectionError):
             Workload(**workload_dict)
 
-    @pytest.mark.only
     def tests_workload_result_set(self, workload):
         workload_dict = workload.dict()
         workload_dict.pop("result")


### PR DESCRIPTION
### Description

- Added `always=True` to results validator
- Added try catch for ConnectionError
- Added test for workload without result defined
- Upgraded version

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
