### PR TITLE
[IMPROVEMENT] HTTP retries with an exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1] - 2024-03-26
+
+### Added
+- A HTTP retry mechanism for the _request() method. The delay between each retry increases exponentially until we reach a retry limit or have a successful request.
 ## [0.7.0] - 2024-03-05
 
 ### Added

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -139,26 +139,6 @@ class Client:
             iteration += 1
 
         return data
-        # exp: Exception = None
-        # for v in range(HTTP_RETRIES):
-        #     delay = (1 * 2) ** v
-        #     try:
-        #         exp = None
-        #         rsp = requests.request(
-        #             method,
-        #             url,
-        #             json=payload,
-        #             timeout=TIMEOUT,
-        #             headers={"content-type": "application/json"},
-        #             auth=self.authenticator,
-        #             params=params,
-        #         )
-        #         data: JSendPayload = rsp.json()
-        #     except Exception as e:
-        #         exp = e
-        #         time.sleep(delay)
-        #         # rsp.raise_for_status()
-        # return data
 
     def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})


### PR DESCRIPTION
### Description

Add a retry mechanism with a exponential backoff delay. We default to 5 retries.

The requests lib provides a retry mechanism built in but it seems to rely on a different interface than the one we are using, I couldn't see how to make use of it but let me know if I wrong about this.

Otherwise, this is a basic while condition where we calculate a new delay on each iteration, based on the iteration we're currently on.


#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
