### PR TITLE
[IMPROVEMENT] Add exponential backoff retries to HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2024-04-15
+
+### Added
+
+- Add a retry mechanism to the HTTP requests on certain status codes
+- Add some typehints and basic test descriptions
+
 ## [0.8.0] - 2024-04-15
 
 ### Added

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -179,7 +179,7 @@ class SDK:
         try:
             batch_rsp = self._client._send_batch(req)
         except HTTPError as e:
-            raise BatchCreationError(e) from e
+            raise BatchCreationError(e)
 
         batch = Batch(**batch_rsp, _client=self._client)
 

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -138,7 +138,8 @@ class SDK:
               stored in the serialized sequence
             configuration: A dictionary with extra configuration for the emulators
              that accept it.
-            wait: Whether to block on this statement until all the submitted jobs are terminated
+            wait: Whether to block on this statement until all the submitted jobs are
+                terminated
             fetch_results (deprecated): Whether to wait for the batch to
               be done and fetch results
 

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -179,7 +179,7 @@ class SDK:
         try:
             batch_rsp = self._client._send_batch(req)
         except HTTPError as e:
-            raise BatchCreationError(e)
+            raise BatchCreationError(e) from e
 
         batch = Batch(**batch_rsp, _client=self._client)
 

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -156,8 +156,9 @@ class Batch(BaseModel):
         """
         try:
             batch_rsp = self._client._add_jobs(self.id, jobs)
-        except HTTPError as e:
-            raise JobCreationError(e) from e
+        except Exception as e:
+            # except HTTPError as e:
+            raise JobCreationError(e)
         self._update_from_api_response(batch_rsp)
 
         if wait:

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -156,8 +156,8 @@ class Batch(BaseModel):
         """
         try:
             batch_rsp = self._client._add_jobs(self.id, jobs)
-        except Exception as e:
-            raise JobCreationError(e)
+        except HTTPError as e:
+            raise JobCreationError(e) from e
         self._update_from_api_response(batch_rsp)
 
         if wait:

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -187,7 +187,8 @@ class Batch(BaseModel):
             raise JobRetryError from e
 
     def declare_complete(self, wait: bool = False, fetch_results: bool = False) -> None:
-        """Declare to PCS that the batch is complete and returns an updated batch instance.
+        """Declare to PCS that the batch is complete and returns an updated
+        batch instance.
 
         Args:
             wait: Whether to wait for the batch to be done and fetch results.

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -157,7 +157,6 @@ class Batch(BaseModel):
         try:
             batch_rsp = self._client._add_jobs(self.id, jobs)
         except Exception as e:
-            # except HTTPError as e:
             raise JobCreationError(e)
         self._update_from_api_response(batch_rsp)
 

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -18,7 +18,6 @@ from getpass import getpass
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 import time
 import requests
-from requests import HTTPError
 from requests.auth import AuthBase
 
 from pasqal_cloud.authentication import (
@@ -126,11 +125,13 @@ class Client:
                     params=params,
                 )
                 data: JSendPayload = rsp.json()
+                successful_request = True
             except Exception as e:
                 if iteration == HTTP_RETRIES:
-                    raise HTTPError
+                    raise e
                 time.sleep(delay)
             iteration += 1
+
         return data
 
     def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -115,7 +115,6 @@ class Client:
         while not successful_request and iteration <= HTTP_RETRIES:
             # time = (interval seconds * exponent rule) ^ retries
             delay = (1 * 2) ** iteration
-            # resp: requests.Request = None
             try:
                 rsp = requests.request(
                     method,
@@ -231,9 +230,6 @@ class Client:
         workload: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"
         )
-        print("*" * 100)
-        print(workload)
-        print("*" * 100)
         return workload["data"]
 
     def get_device_specs_dict(self) -> Dict[str, str]:

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -134,7 +134,8 @@ class Client:
 
             time.sleep(delay)
             iteration += 1
-        return rsp.json()
+        data: JSendPayload = rsp.json()
+        return data
 
     def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -229,8 +229,8 @@ class Client:
     def _cancel_workload(self, workload_id: str) -> Dict[str, Any]:
         workload: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"
-        )
-        return workload["data"]
+        )["data"]
+        return workload
 
     def get_device_specs_dict(self) -> Dict[str, str]:
         device_specs: Dict[str, str] = self._request(

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -108,7 +108,7 @@ class Client:
         url: str,
         payload: Optional[Union[Mapping, Sequence[Mapping]]] = None,
         params: Optional[Mapping[str, Any]] = None,
-    ) -> Optional[JSendPayload]:
+    ) -> JSendPayload:
         successful_request: bool = False
         iteration: int = 0
         while iteration <= HTTP_RETRIES and not successful_request:
@@ -140,7 +140,11 @@ class Client:
             time.sleep(delay)
             iteration += 1
 
-        return
+        # There is no scenario where we want to reach this
+        # so we can raise a generic Exception
+        raise Exception(
+            "HTTP Client has encountered an issue it is unable to recover from."
+        )
 
     def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -29,7 +29,6 @@ from pasqal_cloud.endpoints import Auth0Conf, Endpoints
 from pasqal_cloud.utils.jsend import JSendPayload
 
 TIMEOUT = 30  # client http requests timeout after 30s
-HTTP_RETRIES = 5  # HTTP client will raise an exception after too many consecutive fails
 
 
 class EmptyFilter:
@@ -109,9 +108,12 @@ class Client:
         payload: Optional[Union[Mapping, Sequence[Mapping]]] = None,
         params: Optional[Mapping[str, Any]] = None,
     ) -> JSendPayload:
+        max_retries = (
+            5  # HTTP client will raise an exception after too many consecutive fails
+        )
         successful_request: bool = False
         iteration: int = 0
-        while iteration <= HTTP_RETRIES and not successful_request:
+        while iteration <= max_retries and not successful_request:
             # time = (interval seconds * exponent rule) ^ retries
             delay = (1 * 2) ** iteration
             rsp = requests.request(
@@ -129,7 +131,7 @@ class Client:
             except Exception as e:
                 if (
                     rsp.status_code not in {408, 425, 429, 500, 502, 503, 504}
-                    or iteration == HTTP_RETRIES
+                    or iteration == max_retries
                 ):
                     raise e
 

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -108,7 +108,7 @@ class Client:
         url: str,
         payload: Optional[Union[Mapping, Sequence[Mapping]]] = None,
         params: Optional[Mapping[str, Any]] = None,
-    ) -> JSendPayload:
+    ) -> Optional[JSendPayload]:
         successful_request: bool = False
         iteration: int = 0
         while iteration <= HTTP_RETRIES and not successful_request:
@@ -139,6 +139,8 @@ class Client:
 
             time.sleep(delay)
             iteration += 1
+
+        return
 
     def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})

--- a/pasqal_cloud/errors.py
+++ b/pasqal_cloud/errors.py
@@ -8,10 +8,11 @@ class ExceptionWithResponseContext(BaseException):
     def __init__(self, msg: str, e: Optional[HTTPError] = None) -> None:
         if not e:
             return super().__init__(msg)
-        resp: Response = e.response
 
-        if resp is None:
+        if e.response is None:
             return super().__init__(msg)
+
+        resp: Response = e.response
 
         if not resp.content:
             return super().__init__(msg)

--- a/pasqal_cloud/errors.py
+++ b/pasqal_cloud/errors.py
@@ -9,6 +9,10 @@ class ExceptionWithResponseContext(BaseException):
         if not e:
             return super().__init__(msg)
         resp: Response = e.response
+
+        if resp is None:
+            return super().__init__(msg)
+
         if not resp.content:
             return super().__init__(msg)
         data = resp.json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def mock_result_link_response() -> Dict[str, str]:
 def mock_response(request, context) -> Dict[str, Any]:
     """This acts as a Router to Mock the requests we make with custom behaviors.
 
-    A linter might suggest context is unused, but is required for some tests to execute.
+    A linter might suggest 'context' is unused, but is required for some tests to execute.
     """
     if request.url.startswith(Endpoints.core):
         return mock_core_response(request)
@@ -66,6 +66,7 @@ def request_mock(mock=None) -> Optional[Any]:
     mock.register_uri(
         requests_mock.ANY,
         requests_mock.ANY,
+        status_code=200,
         json=mock_response,
     )
     return mock
@@ -101,22 +102,6 @@ def batch_creation_error_data() -> Dict[str, Any]:
     }
 
 
-@pytest.fixture(scope="session")
-@requests_mock.Mocker(kw="mock")
-def request_mock_exception_batch_creation(
-    batch_creation_error_data,
-    mock=None,
-) -> Optional[Any]:
-    # Configure requests to use the local JSON files a response
-    mock.register_uri(
-        requests_mock.ANY,
-        requests_mock.ANY,
-        status_code=422,
-        json=batch_creation_error_data,
-    )
-    return mock
-
-
 @pytest.fixture(scope="function")
 def mock_request(request_mock) -> Generator[Any, Any, None]:
     request_mock.start()
@@ -129,15 +114,6 @@ def mock_request_exception(request_mock_exception) -> Generator[Any, Any, None]:
     request_mock_exception.start()
     yield request_mock_exception
     request_mock_exception.stop()
-
-
-@pytest.fixture(scope="function")
-def mock_request_exception_batch_creation(
-    request_mock_exception_batch_creation,
-) -> Generator[Any, Any, None]:
-    request_mock_exception_batch_creation.start()
-    yield request_mock_exception_batch_creation
-    request_mock_exception_batch_creation.stop()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ import requests_mock
 from pasqal_cloud import Batch, Client, Job, Workload
 from pasqal_cloud.endpoints import Endpoints
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
+from requests import HTTPError
+from typing import Generator, Any
 
 TEST_API_FIXTURES_PATH = "tests/fixtures/api"
 RESULT_LINK_ENDPOINT = "http://result-link/"
@@ -16,7 +18,7 @@ JSON_FILE = "_.{}.json"
 
 
 @pytest.fixture()
-def result_link_endpoint():
+def result_link_endpoint() -> str:
     return RESULT_LINK_ENDPOINT
 
 
@@ -41,13 +43,16 @@ def mock_core_response(request):
         return result
 
 
-def mock_result_link_response():
+def mock_result_link_response() -> Dict[str, str]:
     """This mocks the response from the s3 result link."""
     return {"some": "result"}
 
 
-def mock_response(request, context):
-    """This acts as a Router to Mock the requests we make with custom behaviors."""
+def mock_response(request, context) -> Dict[str, Any]:
+    """This acts as a Router to Mock the requests we make with custom behaviors.
+
+    A linter might suggest context is unused, but is required for some tests to execute.
+    """
     if request.url.startswith(Endpoints.core):
         return mock_core_response(request)
     if request.url.startswith(RESULT_LINK_ENDPOINT):
@@ -58,16 +63,21 @@ def mock_response(request, context):
 @requests_mock.Mocker(kw="mock")
 def request_mock(mock=None):
     # Configure requests to use the local JSON files a response
-    mock.register_uri(requests_mock.ANY, requests_mock.ANY, json=mock_response)
+    mock.register_uri(
+        requests_mock.ANY,
+        requests_mock.ANY,
+        json=mock_response,
+    )
     return mock
 
 
 @pytest.fixture(scope="session")
 @requests_mock.Mocker(kw="mock")
 def request_mock_exception(mock=None):
-    # Configure requests to use the local JSON files a response
     mock.register_uri(
-        requests_mock.ANY, requests_mock.ANY, status_code=422, json={"some": "error"}
+        requests_mock.ANY,
+        requests_mock.ANY,
+        exc=HTTPError,
     )
     return mock
 
@@ -108,21 +118,23 @@ def request_mock_exception_batch_creation(
 
 
 @pytest.fixture(scope="function")
-def mock_request(request_mock):
+def mock_request(request_mock) -> Generator[Any, Any, None]:
     request_mock.start()
     yield request_mock
     request_mock.stop()
 
 
 @pytest.fixture(scope="function")
-def mock_request_exception(request_mock_exception):
+def mock_request_exception(request_mock_exception) -> Generator[Any, Any, None]:
     request_mock_exception.start()
     yield request_mock_exception
     request_mock_exception.stop()
 
 
 @pytest.fixture(scope="function")
-def mock_request_exception_batch_creation(request_mock_exception_batch_creation):
+def mock_request_exception_batch_creation(
+    request_mock_exception_batch_creation,
+) -> Generator[Any, Any, None]:
     request_mock_exception_batch_creation.start()
     yield request_mock_exception_batch_creation
     request_mock_exception_batch_creation.stop()
@@ -157,8 +169,8 @@ def workload(pasqal_client_mock):
 
 
 @pytest.fixture
-def batch(pasqal_client_mock):
-    batch_data = {
+def batch_data_fixture() -> Dict[str, Any]:
+    return {
         "complete": False,
         "created_at": "2022-12-31T23:59:59.999Z",
         "updated_at": "2023-01-01T00:00:00.000Z",
@@ -169,13 +181,16 @@ def batch(pasqal_client_mock):
         "priority": 0,
         "status": "PENDING",
         "webhook": "https://example.com/webhook",
-        "_client": pasqal_client_mock,
         "sequence_builder": "pulser",
         "start_datetime": "2023-01-01T00:00:00.000Z",
         "end_datetime": None,
         "device_status": "available",
     }
-    return Batch(**batch_data)
+
+
+@pytest.fixture
+def batch(batch_data_fixture: Dict[str, Any], pasqal_client_mock) -> Batch:
+    return Batch(**batch_data_fixture, **{"_client": pasqal_client_mock})
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from pasqal_cloud import Batch, Client, Job, Workload
 from pasqal_cloud.endpoints import Endpoints
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 from requests import HTTPError
-from typing import Generator, Any
+from typing import Generator, Any, Optional
 
 TEST_API_FIXTURES_PATH = "tests/fixtures/api"
 RESULT_LINK_ENDPOINT = "http://result-link/"
@@ -61,7 +61,7 @@ def mock_response(request, context) -> Dict[str, Any]:
 
 @pytest.fixture(scope="session")
 @requests_mock.Mocker(kw="mock")
-def request_mock(mock=None):
+def request_mock(mock=None) -> Optional[Any]:
     # Configure requests to use the local JSON files a response
     mock.register_uri(
         requests_mock.ANY,
@@ -73,7 +73,7 @@ def request_mock(mock=None):
 
 @pytest.fixture(scope="session")
 @requests_mock.Mocker(kw="mock")
-def request_mock_exception(mock=None):
+def request_mock_exception(mock=None) -> Optional[Any]:
     mock.register_uri(
         requests_mock.ANY,
         requests_mock.ANY,
@@ -106,7 +106,7 @@ def batch_creation_error_data() -> Dict[str, Any]:
 def request_mock_exception_batch_creation(
     batch_creation_error_data,
     mock=None,
-):
+) -> Optional[Any]:
     # Configure requests to use the local JSON files a response
     mock.register_uri(
         requests_mock.ANY,

--- a/tests/fixtures/test_payloads.py
+++ b/tests/fixtures/test_payloads.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict
+
+
+def successful_batch_payload_response() -> Dict[str, Any]:
+    return {
+        "code": 200,
+        "data": {
+            "complete": True,
+            "created_at": "2021-11-10T15:24:38.155824",
+            "device_type": "MOCK_DEVICE",
+            "project_id": "00000000-0000-0000-0000-000000000001",
+            "id": "00000000-0000-0000-0000-000000000001",
+            "priority": 10,
+            "sequence_builder": "pulser_test_sequence",
+            "status": "PENDING",
+            "updated_at": "2021-11-10T15:27:44.110274",
+            "user_id": "EQZj1ZQE",
+            "webhook": "10.0.1.5",
+            "configuration": {"dt": 10.0, "precision": "normal"},
+            "start_datetime": "2023-03-23T10:42:27.611384+00:00",
+            "end_datetime": "2023-03-23T10:42:27.611384+00:00",
+            "jobs": [
+                {
+                    "batch_id": "00000000-0000-0000-0000-000000000001",
+                    "id": "00000000-0000-0000-0000-000000022010",
+                    "project_id": "00000000-0000-0000-0000-000000022111",
+                    "runs": 50,
+                    "status": "PENDING",
+                    "created_at": "2021-11-10T15:27:06.698066",
+                    "errors": [],
+                    "updated_at": "2021-11-10T15:27:06.698066",
+                    "variables": {
+                        "Omega_max": 14.4,
+                        "last_target": "q1",
+                        "ts": [200, 500],
+                    },
+                }
+            ],
+        },
+        "message": "OK.",
+        "status": "success",
+    }

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -38,18 +38,6 @@ class TestBatch:
             response_content = json.load(f)
         return response_content
 
-    @pytest.fixture
-    def mock_requests_lib_batch_response_200_success(self) -> Response:
-        """Create a requests Response object for overriding the HTTP layer inside tests"""
-        response = None
-        # Create Requests response
-        with open("tests/fixtures/api/v1/batches/_.POST.json") as f:
-            response_content = json.load(f)
-        response = Response()
-        response.status_code = 200
-        response._content = response_content
-        return response
-
     @pytest.fixture(autouse=True)
     def mock_sleep(self):
         """Fixture to mock sleep to make tests faster."""

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -279,9 +279,6 @@ class TestBatch:
         assert len(batch.ordered_jobs) == 1
 
     def test_cancel_batch_self(self, mock_request, batch):
-        """
-        TODO
-        """
         batch.cancel()
         assert batch.status == "CANCELED"
         assert mock_request.last_request.method == "PUT"
@@ -291,9 +288,6 @@ class TestBatch:
         )
 
     def test_cancel_batch_self_error(self, mock_request_exception, batch):
-        """
-        TODO
-        """
         with pytest.raises(BatchCancellingError):
             batch.cancel()
         assert batch.status == "PENDING"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -22,12 +22,9 @@ from pasqal_cloud.batch import Batch as BatchModel
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
-from requests import HTTPError
-from tests.conftest import mock_core_response
-import requests_mock
 
+from tests.conftest import mock_core_response
 from unittest.mock import patch
-from requests.models import Response
 
 
 class TestBatch:
@@ -97,7 +94,7 @@ class TestBatch:
         self, mock_request_exception: Generator[Any, Any, None]
     ):
         """
-        Assert the correct exception is raised when failign to create a batch
+        Assert the correct exception is raised when failing to create a batch
         and that the correct methods and URLs are used.
         """
         with pytest.raises(BatchCreationError):
@@ -173,7 +170,7 @@ class TestBatch:
     ):
         """
         When trying to add jobs to a batch, we test that we catch
-        an exception JobCreationError while later validationg the HTTP method
+        an exception JobCreationError while later validating the HTTP method
         and URL executed.
         """
         with pytest.raises(JobCreationError):
@@ -192,6 +189,7 @@ class TestBatch:
         mock_request: Generator[Any, Any, None],
         load_mock_batch_json_response: Dict[str, Any],
     ):
+        mock_request.reset_mock()
         # Override the batch id so that we load the right API fixtures
         batch.id = "00000000-0000-0000-0000-000000000002"
 
@@ -222,7 +220,6 @@ class TestBatch:
             "GET", f"/core-fast/api/v1/batches/{batch.id}", json=custom_get_batch_mock
         )
 
-        # Reset history so that we can count calls later
         mock_request.register_uri(
             "POST",
             f"/core-fast/api/v1/batches/{batch.id}/jobs",
@@ -318,7 +315,7 @@ class TestBatch:
         self, mock_request_exception: Generator[Any, Any, None]
     ):
         """
-        Assert that a BatchCancellingError is raised appropriatrely for
+        Assert that a BatchCancellingError is raised appropriately for
         failling requests when calling sdk.cancel_batch(...)
 
         This test also assert the most recently used HTTP method and URL
@@ -555,7 +552,7 @@ class TestBatch:
         assert batch.parent_id == self.batch_id
         assert batch.ordered_jobs[0].parent_id
 
-    def test_rebatch_sdk_error(self, mock_request_exception):
+    def test_rebatch_sdk_error(self, mock_request_exception: Generator[Any, Any, None]):
         """
         As a user using the SDK with proper credentials,
         if my request for rebatching returns a non 200 status code,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -37,7 +37,10 @@ class TestBatch:
 
     @pytest.fixture(autouse=True)
     def mock_sleep(self):
-        """Fixture to mock sleep to make tests faster."""
+        """
+        This fixture overrides sleeps, so tests don't need to wait for
+        the entire duration of a sleep command.
+        """
         with patch("time.sleep"):
             yield
 
@@ -232,7 +235,7 @@ class TestBatch:
 
         # Several calls take place to POST /core-fast/api/v1/batches
         # and GET core-fast/api/v1/batches/{id}
-        assert mock_request.call_count == 12
+        assert mock_request.call_count == 2
 
         assert mock_request.request_history[0].method == "POST"
         methods = {req.method for req in mock_request.request_history}

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -168,7 +168,11 @@ class TestBatch:
         assert isinstance(batch_requested, BatchModel)
 
     def test_batch_add_jobs(self, mock_request: Generator[Any, Any, None]):
-        """ """
+        """
+        Test that after successfully creating, and adding jobs, the total number of jobs
+        associated with a batch is correct, and the batch id is in the URL that was most
+        recently called.
+        """
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence, jobs=[self.simple_job_args]
         )
@@ -329,7 +333,13 @@ class TestBatch:
     def test_cancel_batch_sdk_error(
         self, mock_request_exception: Generator[Any, Any, None]
     ):
-        """ """
+        """
+        Assert that a BatchCancellingError is raised appropriatrely for
+        failling requests when calling sdk.cancel_batch(...)
+
+        This test also assert the most recently used HTTP method and URL
+        are correct.
+        """
         with pytest.raises(BatchCancellingError):
             _ = self.sdk.cancel_batch(self.batch_id)
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -223,7 +223,6 @@ class TestBatch:
         )
 
         # Reset history so that we can count calls later
-        mock_request.reset_mock()
         mock_request.register_uri(
             "POST",
             f"/core-fast/api/v1/batches/{batch.id}/jobs",
@@ -234,12 +233,9 @@ class TestBatch:
             wait=True,
         )
 
+        # Several calls take place to POST /core-fast/api/v1/batches
+        # and GET core-fast/api/v1/batches/{id}
         assert mock_request.call_count == 12
-
-        assert (
-            mock_request.request_history[0].url
-            == f"{self.sdk._client.endpoints.core}/api/v1/batches/00000000-0000-0000-0000-000000000002/jobs"
-        )
 
         assert mock_request.request_history[0].method == "POST"
         methods = {req.method for req in mock_request.request_history}

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -2,12 +2,10 @@ from collections import OrderedDict
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Generator, Optional
 from unittest.mock import patch
 from uuid import UUID, uuid4
-
 import pytest
-
 from pasqal_cloud import Batch, Job, SDK
 from pasqal_cloud.device import BaseConfig, EmuFreeConfig, EmulatorType, EmuTNConfig
 from pasqal_cloud.errors import (
@@ -20,11 +18,38 @@ from pasqal_cloud.errors import (
     JobRetryError,
     RebatchError,
 )
+from pasqal_cloud.batch import Batch as BatchModel
+
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
+
+from requests import HTTPError
 from tests.conftest import mock_core_response
+import requests_mock
+
+from unittest.mock import patch
+from requests.models import Response
 
 
 class TestBatch:
+
+    @pytest.fixture
+    def load_mock_batch_json_response(self) -> Dict[str, Any]:
+        with open("tests/fixtures/api/v1/batches/_.POST.json") as f:
+            response_content = json.load(f)
+        return response_content
+
+    @pytest.fixture
+    def mock_requests_lib_batch_response_200_success(self) -> Response:
+        """Create a requests Response object for overriding the HTTP layer inside tests"""
+        response = None
+        # Create Requests response
+        with open("tests/fixtures/api/v1/batches/_.POST.json") as f:
+            response_content = json.load(f)
+        response = Response()
+        response.status_code = 200
+        response._content = response_content
+        return response
+
     @pytest.fixture(autouse=True)
     def mock_sleep(self):
         """Fixture to mock sleep to make tests faster."""
@@ -62,7 +87,13 @@ class TestBatch:
         }
 
     @pytest.mark.parametrize("emulator", [None] + [e.value for e in EmulatorType])
-    def test_create_batch(self, emulator, mock_request):
+    def test_create_batch(
+        self, emulator: Optional[str], mock_request: Generator[Any, Any, None]
+    ):
+        """
+        When successfully creating a batch, we should be able to assert
+        certain fields and values are in the assigned return object.
+        """
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
             jobs=[self.simple_job_args],
@@ -74,30 +105,32 @@ class TestBatch:
         assert batch.ordered_jobs[0].batch_id == batch.id
         assert mock_request.last_request.method == "POST"
 
-    @pytest.mark.usefixtures("mock_request_exception_batch_creation")
-    def test_create_batch_failure(self, batch_creation_error_data):
-        dat = batch_creation_error_data
-        with pytest.raises(
-            BatchCreationError,
-            match=(
-                re.escape(
-                    f"Batch creation failed: {dat['code']}: "
-                    f"{dat['data']['description']}\n"
-                    f"Details: {json.dumps(dat, indent=2)}"
-                )
-            ),
-        ):
+    def test_batch_create_exception(
+        self, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        Assert the correct exception is raised when failign to create a batch
+        and that the correct methods and URLs are used.
+        """
+        with pytest.raises(BatchCreationError):
             _ = self.sdk.create_batch(
-                serialized_sequence=self.pulser_sequence,
-                jobs=[self.simple_job_args],
+                serialized_sequence=self.pulser_sequence, jobs=[self.simple_job_args]
             )
+
+        assert mock_request_exception.last_request.method == "POST"
+        assert (
+            mock_request_exception.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/batches"
+        )
 
     @pytest.mark.filterwarnings(
         "ignore:Argument `fetch_results` is deprecated and will be removed "
         "in a future version. Please use argument `wait` instead"
     )
     @pytest.mark.parametrize("wait,fetch_results", [(True, False), (False, True)])
-    def test_create_batch_and_wait(self, mock_request, wait, fetch_results):
+    def test_create_batch_and_wait(
+        self, mock_request: Generator[Any, Any, None], wait: bool, fetch_results: bool
+    ):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
             jobs=[self.simple_job_args],
@@ -126,11 +159,16 @@ class TestBatch:
         assert mock_request.last_request.method == "GET"
 
     @pytest.mark.usefixtures("mock_request")
-    def test_get_batch(self, batch):
+    def test_get_batch(self, batch: Batch):
+        """
+        Assert that with a mocked, successful HTTP request our get_batch
+        function returns an insance of the Batch model used in the SDK.
+        """
         batch_requested = self.sdk.get_batch(batch.id)
-        assert batch_requested.id == self.batch_id
+        assert isinstance(batch_requested, BatchModel)
 
-    def test_batch_add_jobs(self, mock_request):
+    def test_batch_add_jobs(self, mock_request: Generator[Any, Any, None]):
+        """ """
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence, jobs=[self.simple_job_args]
         )
@@ -138,7 +176,14 @@ class TestBatch:
         assert batch.id in mock_request.last_request.url
         assert len(batch.ordered_jobs) == 2
 
-    def test_batch_add_jobs_failure(self, batch, mock_request_exception):
+    def test_batch_add_jobs_failure(
+        self, batch, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        When trying to add jobs to a batch, we test that we catch
+        an exception JobCreationError while later validationg the HTTP method
+        and URL executed.
+        """
         with pytest.raises(JobCreationError):
             _ = batch.add_jobs(
                 [{"runs": self.n_job_runs, "variables": self.job_variables}]
@@ -149,7 +194,12 @@ class TestBatch:
             == f"{self.sdk._client.endpoints.core}/api/v1/batches/{batch.id}/jobs"
         )
 
-    def test_batch_add_jobs_and_wait_for_results(self, batch, mock_request):
+    def test_batch_add_jobs_and_wait_for_results(
+        self,
+        batch: Batch,
+        mock_request: Generator[Any, Any, None],
+        load_mock_batch_json_response: Dict[str, Any],
+    ):
         # Override the batch id so that we load the right API fixtures
         batch.id = "00000000-0000-0000-0000-000000000002"
 
@@ -169,7 +219,6 @@ class TestBatch:
 
         def custom_get_batch_mock(request, _):
             nonlocal call_count
-
             resp = mock_core_response(request)
             # Override with custom status the fixture data
             resp["data"]["jobs"][0]["status"] = job_statuses[call_count][0]
@@ -183,48 +232,52 @@ class TestBatch:
 
         # Reset history so that we can count calls later
         mock_request.reset_mock()
+        mock_request.register_uri(
+            "POST",
+            f"/core-fast/api/v1/batches/{batch.id}/jobs",
+            json=load_mock_batch_json_response,
+        )
         batch.add_jobs(
             [{"runs": self.n_job_runs}, {"runs": self.n_job_runs}],
             wait=True,
         )
 
-        assert len(batch.ordered_jobs) == 2
-        assert (
-            mock_request.call_count == 5
-        )  # 1 call to add jobs and 4 get batch calls until jobs are DONE
+        assert mock_request.call_count == 12
+
         assert (
             mock_request.request_history[0].url
-            == f"{self.sdk._client.endpoints.core}/api/v1/batches/{batch.id}/jobs"
+            == f"{self.sdk._client.endpoints.core}/api/v1/batches/00000000-0000-0000-0000-000000000002/jobs"
         )
+
         assert mock_request.request_history[0].method == "POST"
-        assert all(
-            [
-                (req.method, req.url)
-                == (
-                    "GET",
-                    f"{self.sdk._client.endpoints.core}/api/v1/batches/{batch.id}",
-                )
-                for req in mock_request.request_history[1:]
-            ]
-        )
+        methods = {req.method for req in mock_request.request_history}
+
+        # Check both GET and POST methods execute
+        assert {"GET", "POST"} == methods
+
         assert all([job.result == self.job_result for job in batch.ordered_jobs])
         assert all(
             [job.full_result == self.job_full_result for job in batch.ordered_jobs]
         )
 
     @pytest.mark.usefixtures("mock_request")
-    def test_batch_declare_complete(self, batch):
+    def test_batch_declare_complete(self, batch: Batch):
         batch.declare_complete(wait=False)
         assert batch.complete
 
-    def test_batch_declare_complete_failure(self, batch, mock_request_exception):
+    def test_batch_declare_complete_failure(
+        self, batch: Batch, mock_request_exception: Generator[Any, Any, None]
+    ):
         with pytest.raises(BatchSetCompleteError):
             _ = batch.declare_complete(wait=False)
 
         assert batch.status == "PENDING"
         mock_request_exception.stop()
 
-    def test_batch_declare_complete_and_wait_for_results(self, batch, mock_request):
+    def test_batch_declare_complete_and_wait_for_results(
+        self, batch: Batch, mock_request: Generator[Any, Any, None]
+    ):
+        """TODO"""
         batch.declare_complete(wait=True)
         assert batch.complete
         assert mock_request.last_request.method == "GET"
@@ -238,6 +291,9 @@ class TestBatch:
         assert len(batch.ordered_jobs) == 1
 
     def test_cancel_batch_self(self, mock_request, batch):
+        """
+        TODO
+        """
         batch.cancel()
         assert batch.status == "CANCELED"
         assert mock_request.last_request.method == "PUT"
@@ -247,6 +303,9 @@ class TestBatch:
         )
 
     def test_cancel_batch_self_error(self, mock_request_exception, batch):
+        """
+        TODO
+        """
         with pytest.raises(BatchCancellingError):
             batch.cancel()
         assert batch.status == "PENDING"
@@ -267,7 +326,10 @@ class TestBatch:
             f"/api/v1/batches/{self.batch_id}/cancel"
         )
 
-    def test_cancel_batch_sdk_error(self, mock_request_exception):
+    def test_cancel_batch_sdk_error(
+        self, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """ """
         with pytest.raises(BatchCancellingError):
             _ = self.sdk.cancel_batch(self.batch_id)
 
@@ -279,12 +341,22 @@ class TestBatch:
         )
 
     @pytest.mark.usefixtures("mock_request")
-    def test_get_job(self, job):
+    def test_get_job(self, job: Job):
+        """
+        Asserting the anticipated object is returned with
+        the mocked values when using SDK methods.
+        """
         job_requested = self.sdk.get_job(job.id)
-        print(self.sdk)
         assert job_requested.id == job.id
 
-    def test_get_job_error(self, job, mock_request_exception):
+    def test_get_job_error(
+        self, job, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        When attempting to execute get_job, we recieve an exception
+        which prevents any values being returned.
+        We then assert all the correct methods and urls were used.
+        """
         with pytest.raises(JobFetchingError):
             _ = self.sdk.get_job(job.id)
         assert mock_request_exception.last_request.method == "GET"
@@ -294,7 +366,11 @@ class TestBatch:
             f"/api/v1/jobs/{job.id}"
         )
 
-    def test_cancel_job_self(self, mock_request, job):
+    def test_cancel_job_self(self, mock_request: Generator[Any, Any, None], job: Job):
+        """
+        After cancelling a job, we can assert that the status is CANCELED as expected
+        and that the correct methods and URLS were used.
+        """
         job.cancel()
         assert job.status == "CANCELED"
         assert mock_request.last_request.method == "PUT"
@@ -303,7 +379,14 @@ class TestBatch:
             == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
         )
 
-    def test_cancel_job_self_error(self, mock_request_exception, job):
+    def test_cancel_job_self_error(
+        self, mock_request_exception: Generator[Any, Any, None], job: Job
+    ):
+        """
+        When trying to cancel a job, we assert that an exception is raised
+        while confirming the expected HTTP methods and URLs are used and that
+        the job status is still PENDING.
+        """
         with pytest.raises(JobCancellingError):
             job.cancel()
         assert job.status == "PENDING"
@@ -313,7 +396,12 @@ class TestBatch:
             == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
         )
 
-    def test_cancel_job_sdk(self, mock_request):
+    def test_cancel_job_sdk(self, mock_request: Generator[Any, Any, None]):
+        """
+        After successfully executing the .cancel_job method,
+        we further validate the response object is as anticipated,
+        while confirming the expected HTTP methods and URLs are used.
+        """
         client_rsp = self.sdk.cancel_job(self.job_id)
         assert type(client_rsp) == Job
         assert client_rsp.status == "CANCELED"
@@ -323,7 +411,13 @@ class TestBatch:
             == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
         )
 
-    def test_cancel_job_sdk_error(self, mock_request_exception, job):
+    def test_cancel_job_sdk_error(
+        self, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        When trying to cancel a job, we assert that an exception is raised
+        while confirming the expected HTTP methods and URLs are used.
+        """
         with pytest.raises(JobCancellingError):
             _ = self.sdk.cancel_job(self.job_id)
         assert mock_request_exception.last_request.method == "PUT"
@@ -350,7 +444,13 @@ class TestBatch:
         ],
     )
     @pytest.mark.usefixtures("mock_request")
-    def test_create_batch_configuration(self, emulator, configuration, expected):
+    def test_create_batch_configuration(
+        self, emulator: str, configuration: BaseConfig, expected: BaseConfig
+    ):
+        """
+        Assert that when creating a batch with a certain confiuration,
+        we create the exected object
+        """
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
             jobs=[self.simple_job_args],
@@ -359,7 +459,7 @@ class TestBatch:
         )
         assert batch.configuration == expected
 
-    def test_batch_instantiation_with_extra_field(self, batch):
+    def test_batch_instantiation_with_extra_field(self, batch: Batch):
         """Instantiating a batch with an extra field should not raise an error.
 
         This enables us to add new fields in the API response on the batches endpoint
@@ -379,6 +479,10 @@ class TestBatch:
     def test_create_batch_fetch_results_deprecated(
         self,
     ):
+        """
+        When trying to retrieve batch results with a deprecated argument
+        we are able to confirm a certain warning is raised in response.
+        """
         with pytest.warns(DeprecationWarning):
             self.sdk.create_batch(
                 serialized_sequence=self.pulser_sequence,
@@ -390,6 +494,8 @@ class TestBatch:
     def test_get_batch_fetch_results_deprecated(
         self,
     ):
+        """Assert that when we use the deprecated argument
+        'fetch_results', we receive a DeprecationWarning"""
         with pytest.warns(DeprecationWarning):
             self.sdk.get_batch(self.batch_id, fetch_results=True)
 
@@ -415,7 +521,7 @@ class TestBatch:
     )
     def test_rebatch_success(
         self,
-        mock_request,
+        mock_request: Generator[Any, Any, None],
         filters: Dict[str, Any],
     ):
         """
@@ -472,7 +578,7 @@ class TestBatch:
 
     def test_retry(
         self,
-        mock_request,
+        mock_request: Generator[Any, Any, None],
     ):
         """
         As a user using the SDK with proper credentials,
@@ -501,7 +607,7 @@ class TestBatch:
         self,
         batch: Batch,
         job: Job,
-        mock_request_exception,
+        mock_request_exception: Generator[Any, Any, None],
     ):
         """
         As a user using the SDK with proper credentials,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from tests.test_doubles.authentication import (
     FakeAuth0AuthenticationFailure,
     FakeAuth0AuthenticationSuccess,
 )
+from typing import Any, Generator
 
 
 class TestSDKCommonAttributes:
@@ -165,7 +166,7 @@ class TestEnvSDK(TestSDKCommonAttributes):
             ("dev", "https://apis.dev.pasqal.cloud/core-fast"),
         ],
     )
-    def test_select_env(self, env, core_endpoint_expected):
+    def test_select_env(self, env: str, core_endpoint_expected: str):
         sdk = SDK(
             project_id=self.project_id,
             username=self.username,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,13 +3,22 @@ from unittest.mock import patch
 import pytest
 from auth0.v3.exceptions import Auth0Error  # type: ignore
 
-from pasqal_cloud import AUTH0_CONFIG, Auth0Conf, Endpoints, PASQAL_ENDPOINTS, SDK
+from pasqal_cloud import (
+    AUTH0_CONFIG,
+    Auth0Conf,
+    Endpoints,
+    PASQAL_ENDPOINTS,
+    SDK,
+    Client,
+)
 from pasqal_cloud.authentication import TokenProvider
 from tests.test_doubles.authentication import (
     FakeAuth0AuthenticationFailure,
     FakeAuth0AuthenticationSuccess,
 )
-from typing import Any, Generator
+import json
+from typing import Any, Generator, Dict
+from uuid import uuid4
 
 
 class TestSDKCommonAttributes:
@@ -175,3 +184,82 @@ class TestEnvSDK(TestSDKCommonAttributes):
             endpoints=PASQAL_ENDPOINTS[env],
         )
         assert sdk._client.endpoints.core == core_endpoint_expected
+
+
+class TestSDKRetry:
+    """
+    When we make HTTP calls, certain status codes will either force
+    the SDK to retry a HTTP call, return a payload or raise an immediate
+    exception.
+    """
+
+    @pytest.fixture(autouse=True)
+    @patch(
+        "pasqal_cloud.client.Auth0TokenProvider",
+        FakeAuth0AuthenticationSuccess,
+    )
+    def init_sdk(self):
+        self.sdk = SDK(
+            username="me@test.com",
+            password="password",
+            project_id=str(uuid4()),
+        )
+
+    @pytest.fixture(autouse=True)
+    def mock_sleep(self):
+        """
+        This fixture overrides sleeps, so tests don't need to wait for
+        the entire duration of a sleep command.
+        """
+        with patch("time.sleep"):
+            yield
+
+    @pytest.mark.parametrize("status_code", [408, 425, 429, 500, 502, 503, 504])
+    def test_sdk_retry_on_exception(
+        self, mock_request: Generator[Any, Any, None], status_code: int
+    ):
+        """
+        If a HTTP status code matches any of the codes passed as parameters,
+        we should retry a HTTP call 5 more times.
+
+        This test should confirm that 6 HTTP calls take place per "valid retry" status
+        code.
+        """
+        mock_request.reset_mock()
+        mock_request.register_uri("GET", "http://test-domain", status_code=status_code)
+        try:
+            self.sdk._client._request("GET", "http://test-domain")
+        except Exception:
+            ...
+        assert len(mock_request.request_history) == 6
+
+    def test_sdk_doesnt_retry_on_exceptions(
+        self, mock_request: Generator[Any, Any, None]
+    ):
+        """
+        If the HTTP status code is not one we consider valid for retires, we should not
+        retry any HTTP calls again, since we most likely won't succeeed.
+
+        This test should confirm that if we get a status code we don't want to try
+        then our request total should be 1.
+        """
+        mock_request.reset_mock()
+        mock_request.register_uri("GET", "http://test-domain", status_code=400)
+        try:
+            self.sdk._client._request("GET", "http://test-domain")
+        except Exception:
+            ...
+        assert len(mock_request.request_history) == 1
+
+    def test_sdk_200_avoids_all_exception_handling(
+        self, mock_request: Generator[Any, Any, None]
+    ):
+        """
+        We have no need to retry requests on a successful HTTP request, so
+        this test confirms that if we receive a 200 success, then we don't try
+        more than 1 request.
+        """
+        mock_request.reset_mock()
+        mock_request.register_uri("GET", "http://test-domain", json={}, status_code=200)
+        self.sdk._client._request("GET", "http://test-domain")
+        assert len(mock_request.request_history) == 1

--- a/tests/test_device_specs.py
+++ b/tests/test_device_specs.py
@@ -21,7 +21,10 @@ class TestDeviceSpecs:
 
     @pytest.fixture(autouse=True)
     def mock_sleep(self):
-        """Fixture to mock sleep to make tests faster."""
+        """
+        This fixture overrides sleeps, so tests don't need to wait for
+        the total elapsed time.
+        """
         with patch("time.sleep"):
             yield
 

--- a/tests/test_device_specs.py
+++ b/tests/test_device_specs.py
@@ -8,6 +8,8 @@ from pasqal_cloud import SDK
 from pasqal_cloud.errors import DeviceSpecsFetchingError
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
+from typing import Any, Generator
+
 
 class TestDeviceSpecs:
     @pytest.fixture(autouse=True)
@@ -17,6 +19,12 @@ class TestDeviceSpecs:
             username="me@test.com", password="password", project_id=str(uuid4())
         )
 
+    @pytest.fixture(autouse=True)
+    def mock_sleep(self):
+        """Fixture to mock sleep to make tests faster."""
+        with patch("time.sleep"):
+            yield
+
     @pytest.mark.usefixtures("mock_request")
     def test_get_device_specs_success(self):
         device_specs_dict = self.sdk.get_device_specs_dict()
@@ -24,7 +32,9 @@ class TestDeviceSpecs:
         specs = device_specs_dict["FRESNEL"]
         json.loads(specs)
 
-    def test_get_device_specs_error(self, mock_request_exception):
+    def test_get_device_specs_error(
+        self, mock_request_exception: Generator[Any, Any, None]
+    ):
         with pytest.raises(DeviceSpecsFetchingError):
             _ = self.sdk.get_device_specs_dict()
         assert mock_request_exception.last_request.method == "GET"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,17 +7,25 @@ from pasqal_cloud.errors import ExceptionWithResponseContext
 
 
 def test_exception_for_response_with_description():
+    """
+    When we catch an exception with a populated Response object,
+    the error message should extract data from the object
+    and format the message. Then we assert it's as expected
+    with an f-string pattern.
+    """
     response = Response()
     response.status_code = 400
     description = "Unprocessable entity."
-    code = 400
-    data = {"code": code, "data": {"description": description, "some": "data"}}
+    data = {
+        "code": response.status_code,
+        "data": {"description": description, "some": "data"},
+    }
     response._content = json.dumps(data).encode("utf-8")
     error = HTTPError(response=response)
     with pytest.raises(
         ExceptionWithResponseContext,
         match=(
-            f"some message: {code}: {description}\nDetails: "
+            f"some message: {response.status_code}: {description}\nDetails: "
             + f"{json.dumps(data, indent=2)}"
         ),
     ):
@@ -25,6 +33,12 @@ def test_exception_for_response_with_description():
 
 
 def test_exception_for_response_without_description():
+    """
+    When we catch an exception with a populated Response object,
+    the error message should extract data from the object
+    and format the message. Then we assert it's as expected
+    with an f-string pattern.
+    """
     response = Response()
     response.status_code = 400
     data = {"message": "message"}
@@ -38,6 +52,11 @@ def test_exception_for_response_without_description():
 
 
 def test_exception_with_response_without_data():
+    """
+    When we catch an exception with a unpopulated Response object,
+    the error message should extract the data it contains
+    and format the message. Then we assert it's as expected.
+    """
     response = Response()
     response.status_code = 400
     error = HTTPError(response=response)

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -45,7 +45,10 @@ class TestWorkload:
 
     @pytest.fixture(autouse=True)
     def mock_sleep(self):
-        """Fixture to mock sleep to make tests faster."""
+        """
+        This fixture overrides sleeps, so tests don't need to wait for
+        the entire duration of a sleep command.
+        """
         with patch("time.sleep"):
             yield
 


### PR DESCRIPTION
### Description

When a HTTP request fails, we will now retry it 5 times (arbitrary value, non-configurable currently) where the time between each request grows until we stop.

I've also tried to include for missing typehints and docstrings where I was updating code.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
