### PR TITLE
[DEP] Bump Pydantic to V2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Upgrading Pydantic from V1.10 to V2.6.4
+- Upgrading Pydantic from V1.10 to V2.6.4.
 - Updated documentation.
 
 ## [0.7.0] - 2024-03-05
@@ -21,17 +21,17 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added feature to "rebatch" for a closed batch
-- Added `parent_id` param to batch and job
-- Updated documentation
+- Added feature to "rebatch" for a closed batch.
+- Added `parent_id` param to batch and job.
+- Updated documentation.
 
 ## [0.5.0] - 2024-02-05
 
 ### Added
 
 - Added feature to create an "open" batch.
-  - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK
-  - To add jobs to an open batch, use the `add_jobs` method
+  - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
+  - To add jobs to an open batch, use the `add_jobs` method.
 - Updated documentation to add examples to create open batches.
 - The `wait` argument now waits for all the jobs to be terminated instead of waiting for the batch to be terminated.
 
@@ -39,8 +39,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- CRUCIAL BUGFIX - download results properly from result link
-- Added exception case for results download
+- CRUCIAL BUGFIX - download results properly from result link.
+- Added exception case for results download.
 
 ## [0.4.2] - 2023-10-09
 
@@ -57,24 +57,24 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added `result_link` field to `Workload` object
+- Added `result_link` field to `Workload` object.
 
 ### Changed
 
-- `get_workload` now targets v2 of workloads endpoints
-- `result` is built from `result_link` where results are downloaded from temp s3 link
+- `get_workload` now targets v2 of workloads endpoints.
+- `result` is built from `result_link` where results are downloaded from temp s3 link.
 
 ## [0.4.0] - 2023-10-02
 
 ### Added
 
 - Added exception classes for all possible failures (mostly related to client errors).
-- Added try-catch to corresponding methods to raise proper error
+- Added try-catch to corresponding methods to raise proper error.
 
 ### Changed
 
 - Use `raise_for_status` on response from client before returning `data` to get accurate exception.
-- Bumped minor as new exceptions are raised
+- Bumped minor as new exceptions are raised.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Upgrading Pydantic from V1.10 to V2.6.1.
+- Upgrading Pydantic requirement from V1.10.x to >= V2.6.1.
 - Updated documentation.
 
 ## [0.7.0] - 2024-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Upgrading Pydantic requirement from V1.10.x to >= V2.6.1.
+- Upgrading Pydantic requirement from V1.10.x to >= V2.6.0.
 - Updated documentation.
 
 ## [0.7.0] - 2024-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Upgrading Pydantic from V1.10 to V2.6.4.
+- Upgrading Pydantic from V1.10 to V2.6.1.
 - Updated documentation.
 
 ## [0.7.0] - 2024-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1] - 2024-03-11
+
+### Added
+
+- Upgrading Pydantic from V1.10 to V2.6.4
+- Updated documentation.
+
 ## [0.7.0] - 2024-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.7.1] - 2024-03-11
+## [0.7.1] - 2024-04-11
 
 ### Added
 

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime
 import time
-from requests.exceptions import HTTPError
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 from warnings import warn
+
+from requests.exceptions import HTTPError
 
 from pasqal_cloud.authentication import TokenProvider
 from pasqal_cloud.batch import Batch, RESULT_POLLING_INTERVAL

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/pasqal_cloud/authentication.py
+++ b/pasqal_cloud/authentication.py
@@ -29,8 +29,7 @@ class TokenProviderError(Exception):
 
 
 class TokenProvider(ABC):
-    def __init__(self, *args: list[Any], **kwargs: dict):
-        ...
+    def __init__(self, *args: list[Any], **kwargs: dict): ...
 
     @abstractmethod
     def get_token(self) -> str:

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -82,7 +82,7 @@ class Batch(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    def __init__(self, _client: Client, **data):
+    def __init__(self, _client: Client, **data: Any):
         data.update(_client=_client)
         super().__init__(**data)
         self._client = _client
@@ -116,7 +116,7 @@ class Batch(BaseModel):
         return {job.id: job for job in self.ordered_jobs}
 
     @jobs.setter
-    def jobs(self, _):
+    def jobs(self, _: Any) -> None:
         # Do not set jobs attribute as it built from ordered_jobs
         pass
 

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -4,10 +4,11 @@ from warnings import warn
 
 from pydantic import (
     BaseModel,
-    ValidationInfo,
+    ConfigDict,
     field_validator,
     model_validator,
-    ConfigDict, PrivateAttr,
+    PrivateAttr,
+    ValidationInfo,
 )
 from requests import HTTPError
 
@@ -15,9 +16,9 @@ from pasqal_cloud.client import Client
 from pasqal_cloud.device import EmulatorType
 from pasqal_cloud.device.configuration import BaseConfig, EmuFreeConfig, EmuTNConfig
 from pasqal_cloud.errors import (
+    BatchCancellingError,
     BatchFetchingError,
     BatchSetCompleteError,
-    BatchCancellingError,
     JobCreationError,
     JobRetryError,
 )

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -84,7 +84,7 @@ class Batch(BaseModel):
 
     def __init__(self, **data):
         """
-        Makes sure the _client is set when instantiating a Batch
+        Makes sure the '_client' is set when instantiating a Batch
         as Pydantic V2 does not support private attributes.
         """
         super().__init__(**data)

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -82,7 +82,7 @@ class Batch(BaseModel):
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
-    def __init__(self, **data):
+    def __init__(self, **data: Any) -> None:
         """
         Makes sure the '_client' is set when instantiating a Batch
         as Pydantic V2 does not support private attributes.

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, Dict, List, Optional, Type, Union
 from warnings import warn
 
-from pydantic import BaseModel, Extra, root_validator, validator
+from pydantic import BaseModel, Extra, field_validator, model_validator
 from requests import HTTPError
 
 from pasqal_cloud.client import Client
@@ -13,7 +13,6 @@ from pasqal_cloud.errors import (
     BatchSetCompleteError,
     BatchCancellingError,
     JobCreationError,
-    JobFetchingError,
     JobRetryError,
 )
 from pasqal_cloud.job import CreateJob, Job
@@ -79,7 +78,7 @@ class Batch(BaseModel):
         extra = Extra.allow
         arbitrary_types_allowed = True
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
     def _build_ordered_jobs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """This root validator will modify the 'jobs' attribute which is a list
         of jobs dictionaries ordered by creation time before instantiation.
@@ -107,7 +106,7 @@ class Batch(BaseModel):
         )
         return {job.id: job for job in self.ordered_jobs}
 
-    @validator("configuration", pre=True)
+    @field_validator("configuration", mode="before")
     def _load_configuration(
         cls,
         configuration: Union[Dict[str, Any], BaseConfig, None],

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -116,7 +116,7 @@ class Batch(BaseModel):
 
     @jobs.setter
     def jobs(self, _: Any) -> None:
-        # Does not set jobs attribute as it is built from 'ordered_jobs'
+        # Does not set 'jobs' as it is built from 'ordered_jobs'
         pass
 
     @field_validator("configuration", mode="before")

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, Dict, List, Optional, Type, Union
 from warnings import warn
 
-from pydantic import BaseModel, Extra, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 from requests import HTTPError
 
 from pasqal_cloud.client import Client
@@ -20,11 +20,11 @@ from pasqal_cloud.job import CreateJob, Job
 RESULT_POLLING_INTERVAL = 2  # seconds
 
 
-class Batch(BaseModel):
+class Batch(BaseModel, extra="allow"):
     """Class to load batch data return by the API.
 
     A batch groups up several jobs with the same sequence. When a batch is assigned to
-    a QPU, all its jobs are ran sequentially and no other batch can be assigned to the
+    a QPU, all its jobs are run sequentially and no other batch can be assigned to the
     device until all its jobs are done and declared complete.
 
     Attributes:
@@ -62,21 +62,17 @@ class Batch(BaseModel):
     user_id: str
     priority: int
     status: str
-    webhook: Optional[str] = None
     _client: Client
     sequence_builder: str
-    start_datetime: Optional[str] = None
-    end_datetime: Optional[str] = None
-    device_status: Optional[str] = None
     ordered_jobs: List[Job] = []
     jobs_count: int = 0
     jobs_count_per_status: Dict[str, int] = {}
+    webhook: Optional[str] = None
+    start_datetime: Optional[str] = None
+    end_datetime: Optional[str] = None
+    device_status: Optional[str] = None
     parent_id: Optional[str] = None
     configuration: Union[BaseConfig, Dict[str, Any], None] = None
-
-    class Config:
-        extra = Extra.allow
-        arbitrary_types_allowed = True
 
     def __init__(self, _client: Client, **data):
         data.update(_client=_client)
@@ -85,7 +81,7 @@ class Batch(BaseModel):
 
     @model_validator(mode="before")
     def _build_ordered_jobs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """This root validator will modify the 'jobs' attribute which is a list
+        """This root validator will modify the 'jobs' attribute, which is a list
         of jobs dictionaries ordered by creation time before instantiation.
         It will duplicate the value of 'jobs' in a new attribute 'ordered_jobs'
         to keep the jobs ordered by creation time.
@@ -113,7 +109,7 @@ class Batch(BaseModel):
 
     @jobs.setter
     def jobs(self, _):
-        # logger qlq chose
+        # Do not set jobs attribute as it built from ordered_jobs
         pass
 
     @field_validator("configuration", mode="before")

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -2,7 +2,13 @@ import time
 from typing import Any, Dict, List, Optional, Type, Union
 from warnings import warn
 
-from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+    ConfigDict,
+)
 from requests import HTTPError
 
 from pasqal_cloud.client import Client
@@ -20,7 +26,7 @@ from pasqal_cloud.job import CreateJob, Job
 RESULT_POLLING_INTERVAL = 2  # seconds
 
 
-class Batch(BaseModel, extra="allow"):
+class Batch(BaseModel):
     """Class to load batch data return by the API.
 
     A batch groups up several jobs with the same sequence. When a batch is assigned to
@@ -73,6 +79,8 @@ class Batch(BaseModel, extra="allow"):
     device_status: Optional[str] = None
     parent_id: Optional[str] = None
     configuration: Union[BaseConfig, Dict[str, Any], None] = None
+
+    model_config = ConfigDict(extra="allow")
 
     def __init__(self, _client: Client, **data):
         data.update(_client=_client)

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, TypedDict, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PrivateAttr
 from requests import HTTPError
 
 from pasqal_cloud.client import Client
@@ -37,7 +37,7 @@ class Job(BaseModel):
     id: str
     project_id: str
     status: str
-    _client: Client
+    _client: Client = PrivateAttr(default=None)
     created_at: str
     updated_at: str
     errors: Optional[List[str]] = None
@@ -50,12 +50,15 @@ class Job(BaseModel):
     group_id: Optional[str] = None
     parent_id: Optional[str] = None
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
     def __init__(self, _client: Client, **data: Any):
-        data.update(_client=_client)
+        """
+        Makes sure the _client is set when instantiating a Job
+        as Pydantic V2 does not support private attributes.
+        """
         super().__init__(**data)
-        self._client = _client
+        self._client = data["_client"]
 
     def cancel(self) -> Dict[str, Any]:
         """Cancel the current job on the PCS."""

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -54,7 +54,7 @@ class Job(BaseModel):
 
     def __init__(self, **data: Any):
         """
-        Makes sure the _client is set when instantiating a Job
+        Makes sure the '_client' is set when instantiating a Job
         as Pydantic V2 does not support private attributes.
         """
         super().__init__(**data)

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, List, Optional, TypedDict, Union
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 from requests import HTTPError
 
 from pasqal_cloud.client import Client
 from pasqal_cloud.errors import JobCancellingError
 
 
-class Job(BaseModel):
+class Job(BaseModel, extra="allow"):
     """Class for job data.
 
     Attributes:
@@ -49,10 +49,6 @@ class Job(BaseModel):
     # Ticket (#622)
     group_id: Optional[str] = None
     parent_id: Optional[str] = None
-
-    class Config:
-        extra = Extra.allow
-        arbitrary_types_allowed = True
 
     def __init__(self, _client: Client, **data):
         data.update(_client=_client)

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -52,7 +52,7 @@ class Job(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    def __init__(self, _client: Client, **data):
+    def __init__(self, _client: Client, **data: Any):
         data.update(_client=_client)
         super().__init__(**data)
         self._client = _client

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, List, Optional, TypedDict, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from requests import HTTPError
 
 from pasqal_cloud.client import Client
 from pasqal_cloud.errors import JobCancellingError
 
 
-class Job(BaseModel, extra="allow"):
+class Job(BaseModel):
     """Class for job data.
 
     Attributes:
@@ -49,6 +49,8 @@ class Job(BaseModel, extra="allow"):
     # Ticket (#622)
     group_id: Optional[str] = None
     parent_id: Optional[str] = None
+
+    model_config = ConfigDict(extra="allow")
 
     def __init__(self, _client: Client, **data):
         data.update(_client=_client)

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -52,7 +52,7 @@ class Job(BaseModel):
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
-    def __init__(self, _client: Client, **data: Any):
+    def __init__(self, **data: Any):
         """
         Makes sure the _client is set when instantiating a Job
         as Pydantic V2 does not support private attributes.

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -54,6 +54,11 @@ class Job(BaseModel):
         extra = Extra.allow
         arbitrary_types_allowed = True
 
+    def __init__(self, _client: Client, **data):
+        data.update(_client=_client)
+        super().__init__(**data)
+        self._client = _client
+
     def cancel(self) -> Dict[str, Any]:
         """Cancel the current job on the PCS."""
         try:

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -52,7 +52,7 @@ class Job(BaseModel):
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
-    def __init__(self, **data: Any):
+    def __init__(self, **data: Any) -> None:
         """
         Makes sure the '_client' is set when instantiating a Job
         as Pydantic V2 does not support private attributes.

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -54,8 +54,9 @@ class Job(BaseModel):
 
     def __init__(self, **data: Any) -> None:
         """
-        Makes sure the '_client' is set when instantiating a Job
-        as Pydantic V2 does not support private attributes.
+        Workaround to make the private attribute '_client' working
+        like we need with Pydantic V2, more information on:
+        https://docs.pydantic.dev/latest/concepts/models/#private-model-attributes
         """
         super().__init__(**data)
         self._client = data["_client"]

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -54,12 +54,15 @@ class Workload(BaseModel):
     result_link: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
 
-    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True, validate_default=True)
+    model_config = ConfigDict(
+        extra="allow", arbitrary_types_allowed=True, validate_default=True
+    )
 
     def __init__(self, **data: Any) -> None:
         """
-        Makes sure the '_client' is set when instantiating a Workload
-        as Pydantic V2 does not support private attributes.
+        Workaround to make the private attribute '_client' working
+        like we need with Pydantic V2, more information on:
+        https://docs.pydantic.dev/latest/concepts/models/#private-model-attributes
         """
         super().__init__(**data)
         self._client = data["_client"]
@@ -75,11 +78,11 @@ class Workload(BaseModel):
 
     @field_validator("result")
     def result_link_to_result(
-        cls, v: Optional[Dict[str, Any]], info: ValidationInfo
+        cls, result: Optional[Dict[str, Any]], info: ValidationInfo
     ) -> Optional[Dict[str, Any]]:
         result_link: Optional[str] = info.data.get("result_link")
-        if v or not result_link:
-            return v
+        if result or not result_link:
+            return result
         try:
             res = requests.get(result_link)
         except HTTPError as e:

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -57,6 +57,11 @@ class Workload(BaseModel):
         extra = Extra.allow
         arbitrary_types_allowed = True
 
+    def __init__(self, _client: Client, **data):
+        data.update(_client=_client)
+        super().__init__(**data)
+        self._client = _client
+
     def cancel(self) -> Dict[str, Any]:
         """Cancel the current job on the PCS."""
         try:

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 import requests
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, ConfigDict
 from pydantic_core.core_schema import ValidationInfo
 from requests import HTTPError
 
@@ -17,7 +17,7 @@ from pasqal_cloud.errors import (
 )
 
 
-class Workload(BaseModel, extra="allow", validate_default=True):
+class Workload(BaseModel):
     """Class for workload data.
 
     Attributes:
@@ -53,6 +53,8 @@ class Workload(BaseModel, extra="allow", validate_default=True):
     end_timestamp: Optional[str] = None
     result_link: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(extra="allow", validate_default=True)
 
     def __init__(self, _client: Client, **data):
         data.update(_client=_client)

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -56,7 +56,7 @@ class Workload(BaseModel):
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True, validate_default=True)
 
-    def __init__(self, **data):
+    def __init__(self, **data: Any) -> None:
         """
         Makes sure the '_client' is set when instantiating a Workload
         as Pydantic V2 does not support private attributes.

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -56,7 +56,7 @@ class Workload(BaseModel):
 
     model_config = ConfigDict(extra="allow", validate_default=True)
 
-    def __init__(self, _client: Client, **data):
+    def __init__(self, _client: Client, **data: Any):
         data.update(_client=_client)
         super().__init__(**data)
         self._client = _client

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 import requests
-from pydantic import BaseModel, field_validator, ConfigDict, PrivateAttr
+from pydantic import BaseModel, ConfigDict, field_validator, PrivateAttr
 from pydantic_core.core_schema import ValidationInfo
 from requests import HTTPError
 

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -58,7 +58,7 @@ class Workload(BaseModel):
 
     def __init__(self, **data):
         """
-        Makes sure the _client is set when instantiating a Workload
+        Makes sure the '_client' is set when instantiating a Workload
         as Pydantic V2 does not support private attributes.
         """
         super().__init__(**data)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "auth0-python >= 3.23.1, <4.0.0",
         "requests>=2.25.1, <3.0.0",
         "pyjwt[crypto]>=2.5.0, <3.0.0",
-        "pydantic<3.0.0",
+        "pydantic >= 2.6.4, <3.0.0",
     ],
     extras_require={
         "dev": {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "auth0-python >= 3.23.1, <4.0.0",
         "requests>=2.25.1, <3.0.0",
         "pyjwt[crypto]>=2.5.0, <3.0.0",
-        "pydantic >= 2.6.1, <3.0.0",
+        "pydantic >= 2.6.0, <3.0.0",
     ],
     extras_require={
         "dev": {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "auth0-python >= 3.23.1, <4.0.0",
         "requests>=2.25.1, <3.0.0",
         "pyjwt[crypto]>=2.5.0, <3.0.0",
-        "pydantic >= 2.6.4, <3.0.0",
+        "pydantic >= 2.6.1, <3.0.0",
     ],
     extras_require={
         "dev": {

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "black==23.3.0",
             "flake8==6.0.0",
             "isort==5.12.0",
-            "mypy==0.982",
+            "mypy==1.9.0",
             "pytest==7.4.0",
             "pytest-cov==4.1.0",
             "types-requests==2.31.0.1",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "auth0-python >= 3.23.1, <4.0.0",
         "requests>=2.25.1, <3.0.0",
         "pyjwt[crypto]>=2.5.0, <3.0.0",
-        "pydantic>=1.10, <2.0",
+        "pydantic<3.0.0",
     ],
     extras_require={
         "dev": {

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -366,7 +366,7 @@ class TestBatch:
         without breaking compatibility for users with old versions of the SDK where
         the field is not present in the Batch class.
         """
-        batch_dict = batch.dict()  # Batch data expected by the SDK
+        batch_dict = batch.model_dump()  # Batch data expected by the SDK
         # We add an extra field to mimick the API exposing new values to the user
         batch_dict["new_field"] = "any_value"
 

--- a/tests/test_device_specs.py
+++ b/tests/test_device_specs.py
@@ -20,7 +20,7 @@ class TestDeviceSpecs:
     @pytest.mark.usefixtures("mock_request")
     def test_get_device_specs_success(self):
         device_specs_dict = self.sdk.get_device_specs_dict()
-        assert type(device_specs_dict) == dict
+        assert isinstance(device_specs_dict, dict)
         specs = device_specs_dict["FRESNEL"]
         json.loads(specs)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -9,7 +9,7 @@ class TestJob:
         without breaking compatibility for users with old versions of the SDK where
         the field is not present in the Job class.
         """
-        job_dict = job.dict()  # job data expected by the SDK
+        job_dict = job.model_dump()  # job data expected by the SDK
         # We add an extra field to mimick the API exposing new values to the user
         job_dict["new_field"] = "any_value"
 

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -170,7 +170,7 @@ class TestWorkload:
         without breaking compatibility for users with old versions of the SDK where
         the field is not present in the Batch class.
         """
-        workload_dict = workload.dict()  # Batch data expected by the SDK
+        workload_dict = workload.model_dump()  # Batch data expected by the SDK
         # We add an extra field to mimick the API exposing new values to the user
         workload_dict["new_field"] = "any_value"
 
@@ -181,9 +181,9 @@ class TestWorkload:
 
     def test_workload_result_raise_connection_error(self, workload):
         """
-        Check that error is raised when improper url is set.
+        Check that error is raised when an improper url is set.
         """
-        workload_dict = workload.dict()
+        workload_dict = workload.model_dump()
         workload_dict.pop("result")
         workload_dict["result_link"] = "http://test.test"
         with pytest.raises(WorkloadResultsConnectionError):
@@ -193,7 +193,7 @@ class TestWorkload:
         """
         Check that result is set when only result_link is provided.
         """
-        workload_dict = workload.dict()
+        workload_dict = workload.model_dump()
         workload_dict.pop("result")
         workload_dict["result_link"] = "http://test.test"
         resp = requests.Response()


### PR DESCRIPTION
### Description

This PR updates the version of Pydantic required by pasqal-cloud from V1.10 to V2.6.


#### Breaking changes

Now pasqal-cloud needs Pydantic >= 2.6.0 to run.

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
