### PR TITLE
[DEP] Use ruff as a linter and formater instead of flake8, isort and black

### DIFF
--- a/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
+++ b/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Perform unit tests
         run: |
-          pytest -vvv --cov pasqal_cloud tests
+          pytest -vvv --cov
 
       - name: Mypy checks only for Python 3.8
         if: ${{ matrix.python-version == 3.8 }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -8,26 +8,17 @@ repos:
         args:
           - --unsafe
       - id: check-added-large-files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.7
+    hooks:
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.17.0
+    rev: v8.18.3
     hooks:
       - id: gitleaks
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.0
-    hooks:
-      - id: autoflake
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
 
 # See https://pre-commit.com for more information

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -22,11 +22,11 @@ from pasqal_cloud.authentication import TokenProvider
 from pasqal_cloud.batch import Batch, RESULT_POLLING_INTERVAL
 from pasqal_cloud.client import Client, EmptyFilter
 from pasqal_cloud.device import BaseConfig, EmulatorType
-from pasqal_cloud.endpoints import (  # noqa: F401
-    AUTH0_CONFIG,
+from pasqal_cloud.endpoints import (
+    AUTH0_CONFIG,  # noqa: F401
     Auth0Conf,
     Endpoints,
-    PASQAL_ENDPOINTS,
+    PASQAL_ENDPOINTS,  # noqa: F401
 )
 from pasqal_cloud.errors import (
     BatchCancellingError,
@@ -175,7 +175,7 @@ class SDK:
         # The configuration field is only added in the case
         # it's requested
         if configuration:
-            req.update({"configuration": configuration.to_dict()})  # type: ignore
+            req.update({"configuration": configuration.to_dict()})  # type: ignore[dict-item]
 
         try:
             batch_rsp = self._client._send_batch(req)
@@ -186,7 +186,7 @@ class SDK:
 
         if wait:
             while any(
-                [job.status in {"PENDING", "RUNNING"} for job in batch.ordered_jobs]
+                job.status in {"PENDING", "RUNNING"} for job in batch.ordered_jobs
             ):
                 time.sleep(RESULT_POLLING_INTERVAL)
                 batch.refresh()
@@ -230,8 +230,7 @@ class SDK:
             batch_rsp = self._client._cancel_batch(id)
         except HTTPError as e:
             raise BatchCancellingError(e) from e
-        batch = Batch(**batch_rsp, _client=self._client)
-        return batch
+        return Batch(**batch_rsp, _client=self._client)
 
     def rebatch(
         self,
@@ -297,8 +296,7 @@ class SDK:
             while job_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
                 job_rsp = self._get_job(id)
-        job = Job(**job_rsp, _client=self._client)
-        return job
+        return Job(**job_rsp, _client=self._client)
 
     def cancel_job(self, id: str) -> Job:
         """Cancel the given job on the PCS
@@ -311,8 +309,7 @@ class SDK:
         except HTTPError as e:
             raise JobCancellingError(e) from e
 
-        job = Job(**job_rsp, _client=self._client)
-        return job
+        return Job(**job_rsp, _client=self._client)
 
     def _get_workload(self, id: str) -> Dict[str, Any]:
         try:
@@ -382,8 +379,7 @@ class SDK:
         workload_rsp = self._get_workload(id)
         if wait:
             workload_rsp = self.wait_for_workload(id, workload_rsp)
-        workload = Workload(**workload_rsp, _client=self._client)
-        return workload
+        return Workload(**workload_rsp, _client=self._client)
 
     def cancel_workload(self, id: str) -> Workload:
         """Cancel the given workload on the PCS.
@@ -401,8 +397,7 @@ class SDK:
             workload_rsp = self._client._cancel_workload(id)
         except HTTPError as e:
             raise WorkloadCancellingError(e) from e
-        workload = Workload(**workload_rsp, _client=self._client)
-        return workload
+        return Workload(**workload_rsp, _client=self._client)
 
     def get_device_specs_dict(self) -> Dict[str, str]:
         """Retrieve the list of available device specifications.

--- a/pasqal_cloud/authentication.py
+++ b/pasqal_cloud/authentication.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
-from auth0.v3.authentication import GetToken  # type: ignore
+from auth0.v3.authentication import GetToken  # type: ignore[import-untyped]
 from jwt import decode, DecodeError
 from requests import PreparedRequest
 from requests.auth import AuthBase
@@ -93,7 +93,7 @@ class ExpiringTokenProvider(TokenProvider, ABC):
         Returns:
             The time the token will expire, or None if it can't be calculated
         """
-        expires_in = token_response.get("expires_in", None)
+        expires_in = token_response.get("expires_in")
         if expires_in:
             return datetime.now(tz=timezone.utc) + timedelta(seconds=float(expires_in))
 

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -162,7 +162,7 @@ class Batch(BaseModel):
 
         if wait:
             while any(
-                [job.status in {"PENDING", "RUNNING"} for job in self.ordered_jobs]
+                job.status in {"PENDING", "RUNNING"} for job in self.ordered_jobs
             ):
                 time.sleep(RESULT_POLLING_INTERVAL)
                 self.refresh()
@@ -206,7 +206,7 @@ class Batch(BaseModel):
         self._update_from_api_response(batch_rsp)
         if wait or fetch_results:
             while any(
-                [job.status in {"PENDING", "RUNNING"} for job in self.ordered_jobs]
+                job.status in {"PENDING", "RUNNING"} for job in self.ordered_jobs
             ):
                 time.sleep(RESULT_POLLING_INTERVAL)
                 self.refresh()

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 from __future__ import annotations
 
+import time
 from datetime import datetime
 from getpass import getpass
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
-import time
+
 import requests
 from requests.auth import AuthBase
 
@@ -150,18 +151,18 @@ class Client:
 
     def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})
-        batch_data = self._request(
+        response: Dict[str, Any] = self._request(
             "POST",
             f"{self.endpoints.core}/api/v1/batches",
             batch_data,
         )["data"]
-        return batch_data
+        return response
 
-    def _get_batch(self, id: str) -> Dict[str, Any]:
-        batch_data: Dict[str, Any] = self._request(
-            "GET", f"{self.endpoints.core}/api/v1/batches/{id}"
+    def _get_batch(self, batch_id: str) -> Dict[str, Any]:
+        response: Dict[str, Any] = self._request(
+            "GET", f"{self.endpoints.core}/api/v1/batches/{batch_id}"
         )["data"]
-        return batch_data
+        return response
 
     def _complete_batch(self, batch_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
@@ -170,10 +171,10 @@ class Client:
         return response
 
     def _cancel_batch(self, batch_id: str) -> Dict[str, Any]:
-        batch: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/batches/{batch_id}/cancel"
         )["data"]
-        return batch
+        return response
 
     def rebatch(
         self,
@@ -199,12 +200,12 @@ class Client:
         if not isinstance(end_date, EmptyFilter):
             query_params["end_date"] = end_date.isoformat()
 
-        new_batch: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._request(
             "POST",
             f"{self.endpoints.core}/api/v1/batches/{batch_id}/rebatch",
             params=query_params,
         )["data"]
-        return new_batch
+        return response
 
     def _add_jobs(
         self, batch_id: str, jobs_data: Sequence[Mapping[str, Any]]
@@ -215,40 +216,40 @@ class Client:
         return response
 
     def _get_job(self, job_id: str) -> Dict[str, Any]:
-        job: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._request(
             "GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}"
         )["data"]
-        return job
+        return response
 
     def _cancel_job(self, job_id: str) -> Dict[str, Any]:
-        job: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/jobs/{job_id}/cancel"
         )["data"]
-        return job
+        return response
 
     def _send_workload(self, workload_data: Dict[str, Any]) -> Dict[str, Any]:
         workload_data.update({"project_id": self.project_id})
-        workload_data = self._request(
+        response: Dict[str, Any] = self._request(
             "POST",
             f"{self.endpoints.core}/api/v1/workloads",
             workload_data,
         )["data"]
-        return workload_data
+        return response
 
     def _get_workload(self, workload_id: str) -> Dict[str, Any]:
-        workload: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._request(
             "GET", f"{self.endpoints.core}/api/v2/workloads/{workload_id}"
         )["data"]
-        return workload
+        return response
 
     def _cancel_workload(self, workload_id: str) -> Dict[str, Any]:
-        workload: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"
         )["data"]
-        return workload
+        return response
 
     def get_device_specs_dict(self) -> Dict[str, str]:
-        device_specs: Dict[str, str] = self._request(
+        response: Dict[str, str] = self._request(
             "GET", f"{self.endpoints.core}/api/v1/devices/specs"
         )["data"]
-        return device_specs
+        return response

--- a/pasqal_cloud/device/configuration/__init__.py
+++ b/pasqal_cloud/device/configuration/__init__.py
@@ -7,7 +7,7 @@ from pasqal_cloud.device.configuration.emu_tn import EmuTNConfig
 
 __all__ = [
     "BaseConfig",
-    "InvalidConfiguration",
     "EmuFreeConfig",
     "EmuTNConfig",
+    "InvalidConfiguration",
 ]

--- a/pasqal_cloud/device/configuration/base_config.py
+++ b/pasqal_cloud/device/configuration/base_config.py
@@ -70,13 +70,13 @@ class BaseConfig:
 
         # ensure that no extra config is passed as None
         if not conf:
-            conf = None  # type: ignore
+            conf = None  # type: ignore[assignment]
         return cls(**base_conf, extra_config=conf)
 
     @staticmethod
     def _unnest_extra_config(conf_dict: dict[str, Any]) -> dict[str, Any]:
-        res = {k: v for (k, v) in conf_dict.items() if not k == "extra_config"}
-        if conf_dict.get("extra_config", None):
+        res = {k: v for (k, v) in conf_dict.items() if k != "extra_config"}
+        if conf_dict.get("extra_config"):
             res.update(conf_dict["extra_config"])
         return res
 
@@ -86,13 +86,14 @@ class BaseConfig:
 
     def _validate(self) -> None:
         if self.extra_config:
-            for k in self.extra_config.keys():
-                if k in self.__dataclass_fields__.keys():
+            for k in self.extra_config:
+                if k in self.__dataclass_fields__:
                     raise InvalidConfiguration(INVALID_KEY_ERROR_MSG.format(k))
-        if self.result_types:
-            if not set(self.result_types) <= set(self.allowed_result_types):
-                raise InvalidConfiguration(
-                    INVALID_RESULT_TYPES.format(
-                        self.result_types, self.allowed_result_types
-                    )
+        if self.result_types and not set(self.result_types) <= set(
+            self.allowed_result_types
+        ):
+            raise InvalidConfiguration(
+                INVALID_RESULT_TYPES.format(
+                    self.result_types, self.allowed_result_types
                 )
+            )

--- a/pasqal_cloud/endpoints.py
+++ b/pasqal_cloud/endpoints.py
@@ -17,7 +17,7 @@ from sys import version_info
 if version_info[:2] >= (3, 8):
     from typing import Final
 else:
-    from typing_extensions import Final  # type: ignore
+    from typing_extensions import Final  # type: ignore[assignment]
 
 
 # ---- Endpoints ----

--- a/pasqal_cloud/errors.py
+++ b/pasqal_cloud/errors.py
@@ -5,7 +5,7 @@ from requests import ConnectionError, HTTPError, Response
 
 
 class ExceptionWithResponseContext(BaseException):
-    def __init__(self, msg: str, e: Optional[HTTPError] = None) -> None:
+    def __init__(self, msg: str, e: Optional[HTTPError] = None):
         if not e:
             return super().__init__(msg)
 
@@ -25,7 +25,7 @@ class ExceptionWithResponseContext(BaseException):
         else:
             description = data.get("message", "")
 
-        super().__init__(
+        return super().__init__(
             f"{msg}: {code}: {description}\nDetails: {json.dumps(data, indent=2)}"
         )
 

--- a/pasqal_cloud/utils/strenum.py
+++ b/pasqal_cloud/utils/strenum.py
@@ -10,4 +10,4 @@ class StrEnum(str, Enum):
 
     @classmethod
     def list(cls) -> List[str]:
-        return list(map(lambda c: c.value, cls))  # type: ignore
+        return [c.value for c in cls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,63 @@
-[tool.black]
-line-length = 88
-
-[tool.isort]
-profile = "black"
-skip_gitignore = true
-order_by_type = false
-force_alphabetical_sort_within_sections = true
-
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+
+# Assume Python 3.8
+target-version = "py38"
+
+[tool.ruff.lint]
+# Rules applied by ruff, more information on https://docs.astral.sh/ruff/rules/
+select = [
+    "F",
+    "E",
+    "W",
+    "C90",
+    "I",
+    "C4",
+    "T10",
+    "LOG",
+    "PIE",
+    "T20",
+    "PT",
+    "Q",
+    "RSE",
+    "RET",
+    "SIM",
+    "ARG",
+    "ERA",
+    "FLY",
+    "PERF",
+    "RUF",
+]
+ignore = ["W191", "E111", "E114", "E117", "SIM115"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Excluded paths to lint
+exclude = []
+
+[tool.ruff.lint.isort]
+# Order imports by type, which is determined by case, in addition to alphabetically.
+order-by-type = false
+
+known-third-party = []
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Excluded paths to format
+exclude = []

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -1,9 +1,12 @@
+# ruff: noqa: E402 F403
+
 import warnings
 
 
 def pasqal_sdk_not_updated():
     warnings.warn(
-        "pasqal-sdk package is deprecated, please use pasqal_cloud instead: `pip install pasqal-cloud`",
+        "pasqal-sdk package is deprecated, please use pasqal_cloud"
+        "instead: `pip install pasqal-cloud`",
         DeprecationWarning,
     )
 

--- a/sdk/device/__init__.py
+++ b/sdk/device/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E402 F403
+
 from sdk import pasqal_sdk_not_updated
 
 pasqal_sdk_not_updated()

--- a/sdk/device/configuration/__init__.py
+++ b/sdk/device/configuration/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E402 F403
+
 from sdk import pasqal_sdk_not_updated
 
 pasqal_sdk_not_updated()

--- a/sdk/utils/__init__.py
+++ b/sdk/utils/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E402 F403
+
 from sdk import pasqal_sdk_not_updated
 
 pasqal_sdk_not_updated()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,3 @@
 # This includes the license file(s) in the wheel.
 # https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_files = LICENSE
-
-
-[flake8]
-# Using black's max line length
-max-line-length = 88
-exclude = tests, sdk
-application-import-names=pasqal_cloud
-application-package-names=pasqal_cloud
-import-order-style=smarkets

--- a/setup.py
+++ b/setup.py
@@ -43,14 +43,12 @@ setup(
     ],
     extras_require={
         "dev": {
-            "black==23.3.0",
-            "flake8==6.0.0",
-            "isort==5.12.0",
-            "mypy==1.9.0",
-            "pytest==7.4.0",
-            "pytest-cov==4.1.0",
+            "ruff==0.4.7",
+            "mypy==1.10.0",
+            "pytest==8.1.1",
+            "pytest-cov==5.0.0",
             "types-requests==2.31.0.1",
-            "requests-mock==1.11.0",
+            "requests-mock==1.12.1",
         }
     },
 )

--- a/tests/test_cloud_sdk_import.py
+++ b/tests/test_cloud_sdk_import.py
@@ -1,12 +1,13 @@
-# flake8: noqa
+# ruff: noqa: F401
+
 import inspect
 
 import pytest
 
 """
-Tests written to verify if the backward compatibility is working between the new name of the package `pasqal-cloud`
-and its main folder renamed to `pasqal_cloud` and the previous package name that was `pasqal-cloud`
-with the former folder called `sdk`.
+Tests written to verify if the backward compatibility is working between the new name
+of the package `pasqal-cloud` and its main folder renamed to `pasqal_cloud` and the
+previous package name that was `pasqal-cloud` with the former folder called `sdk`.
 """
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ from pasqal_cloud.device.configuration.result_type import ResultType
 
 
 @pytest.mark.parametrize(
-    "config, expected",
+    ("config", "expected"),
     [
         (
             EmuTNConfig(
@@ -95,7 +95,7 @@ def test_configuration_to_dict(config: BaseConfig, expected: dict):
 
 
 @pytest.mark.parametrize(
-    "config_class, expected, config",
+    ("config_class", "expected", "config"),
     [
         (
             EmuTNConfig,
@@ -157,7 +157,7 @@ def test_configuration_from_dict(
 
 
 @pytest.mark.parametrize(
-    "config, extra_config, expected",
+    ("config", "extra_config", "expected"),
     [
         (EmuTNConfig(), {"dt": 10.0}, INVALID_KEY_ERROR_MSG.format("dt")),
         (EmuTNConfig(dt=-1), None, DT_VALUE_NOT_VALID.format(-1)),

--- a/tests/test_device_specs.py
+++ b/tests/test_device_specs.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Generator
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -8,19 +9,17 @@ from pasqal_cloud import SDK
 from pasqal_cloud.errors import DeviceSpecsFetchingError
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
-from typing import Any, Generator
-
 
 class TestDeviceSpecs:
     @pytest.fixture(autouse=True)
     @patch("sdk.client.Auth0TokenProvider", FakeAuth0AuthenticationSuccess)
-    def init_sdk(self):
+    def _init_sdk(self):
         self.sdk = SDK(
             username="me@test.com", password="password", project_id=str(uuid4())
         )
 
     @pytest.fixture(autouse=True)
-    def mock_sleep(self):
+    def _mock_sleep(self):
         """
         This fixture overrides sleeps, so tests don't need to wait for
         the total elapsed time.

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,9 +1,10 @@
 import json
-import requests
+from typing import Any, Generator
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
+import requests
 
 from pasqal_cloud import SDK, Workload
 from pasqal_cloud.errors import (
@@ -13,16 +14,15 @@ from pasqal_cloud.errors import (
     WorkloadResultsConnectionError,
     WorkloadResultsDecodeError,
 )
-from typing import Any, Generator
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
 
 class TestWorkload:
-    @pytest.fixture
+    @pytest.fixture()
     def workload_with_link_id(self) -> str:
         return str(UUID(int=0x2))
 
-    @pytest.fixture
+    @pytest.fixture()
     def workload_with_invalid_link_id(self) -> str:
         return str(UUID(int=0x3))
 
@@ -31,7 +31,7 @@ class TestWorkload:
         "pasqal_cloud.client.Auth0TokenProvider",
         FakeAuth0AuthenticationSuccess,
     )
-    def init_sdk(self):
+    def _init_sdk(self):
         self.sdk = SDK(
             username="me@test.com",
             password="password",
@@ -44,7 +44,7 @@ class TestWorkload:
         self.workload_result = {"1001": 12, "0110": 35, "1111": 1}
 
     @pytest.fixture(autouse=True)
-    def mock_sleep(self):
+    def _mock_sleep(self):
         """
         This fixture overrides sleeps, so tests don't need to wait for
         the entire duration of a sleep command.
@@ -223,6 +223,6 @@ class TestWorkload:
         workload_dict["result_link"] = "http://test.test"
         resp = requests.Response()
         resp._content = json.dumps({"some": "data"}).encode("utf-8")
-        with patch("requests.get", lambda x: resp):
+        with patch("requests.get", return_value=resp):
             res = Workload(**workload_dict)
         assert res.result == {"some": "data"}


### PR DESCRIPTION
### Description

This PR implements ruff as the new formatter and linter for pasqal-cloud, introducing new rules to make the code cleaner.

All the rules I added in the pyproject.toml can be found on: https://docs.astral.sh/ruff/rules/

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
