### PR TITLE
[FEAT] Get list of jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2024-06-14
+
+### Added
+
+- Introduced a new filtering system using Pydantic classes for more flexible and robust filtering options
+- Added 'get_jobs' method, a feature to retrieve a list of jobs based on 'JobFilters'
+
+### Breaking change
+
+- Updated the 'rebatch' method to use 'RebatchFilters' for filtering jobs to retry,
+  replacing the previous multiple filter parameters
+
 ## [0.10.1] - 2024-06-14
 
 ### Changed
@@ -16,11 +28,6 @@ All notable changes to this project will be documented in this file.
 - Expose add_jobs and close_batch functions in the SDK interface
 - Refactor non-private methods that were prefixed with _
 - Add test coverage for new functions
-
-## [0.9.0] - 2024-06-05
-
-### Changed
-
 - Drop priority from Batch attributes
 
 ## [0.9.0] - 2024-05-15
@@ -70,8 +77,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added feature to create an "open" batch.
-  - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
-  - To add jobs to an open batch, use the `add_jobs` method.
+    - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
+    - To add jobs to an open batch, use the `add_jobs` method.
 - Updated documentation to add examples to create open batches.
 - The `wait` argument now waits for all the jobs to be terminated instead of waiting for the batch to be terminated.
 
@@ -182,7 +189,8 @@ hence the feature was not documented.
 
 ### Changed
 
-Fixed incorrect type hint of user IDs from int to str which was raising a validation exception when loading the data returned by the API.
+Fixed incorrect type hint of user IDs from int to str which was raising a validation exception when loading the data
+returned by the API.
 
 ## [0.2.7] - 2023-06-08
 
@@ -193,8 +201,11 @@ Now you can get the environment configuration for `endpoints` and `auth0` of the
 
 ### Changed
 
-- Batch and Job dataclasses have been replaced by pydantic models, which gives more control to unserialize the API response data.
-  The SDK is now more resilient to API changes, if a new field is added to the response of the API then the job and batch object instantiation will not raise an exception, meaning this SDK version will not become obsolete as soon as the API spec is updated.
+- Batch and Job dataclasses have been replaced by pydantic models, which gives more control to unserialize the API
+  response data.
+  The SDK is now more resilient to API changes, if a new field is added to the response of the API then the job and
+  batch object instantiation will not raise an exception, meaning this SDK version will not become obsolete as soon as
+  the API spec is updated.
 
 ## [0.2.6] - 2023-05-29
 
@@ -276,8 +287,10 @@ Note that for backwards compatibility, the `group_id` is still exposed by the AP
 - The default values for the tensor network emulator were updated to better ones.
 - the client_id and client_secret was leftover in the Client object even though they are no longer used.
 - Updated the README to also supply the group_id which is mandatory.
-- Updated the default endpoint to `/core-fast` in accordance with infra changes. All users should use `/core-fast` in all environments.
-- The PCS APIs Client was refactored to accept any custom token provider for authentication. This can be used by users as an alternative to the username/password-based token provider.
+- Updated the default endpoint to `/core-fast` in accordance with infra changes. All users should use `/core-fast` in
+  all environments.
+- The PCS APIs Client was refactored to accept any custom token provider for authentication. This can be used by users
+  as an alternative to the username/password-based token provider.
 
 ## [0.1.12] - 2023-02-27
 
@@ -299,9 +312,12 @@ Note that for backwards compatibility, the `group_id` is still exposed by the AP
 
 ### Changed
 
-- A new device type, "EMU-TN", corresponding to tensor network-based emulator, was added. The "EMU_SV" type was removed as it is not available right now.
+- A new device type, "EMU-TN", corresponding to tensor network-based emulator, was added. The "EMU_SV" type was removed
+  as it is not available right now.
 
-- A new version of the "core" microservice, using FastAPI instead of Flask as web framework, was released in the "dev" environment. If using the "dev" environment, you should upgrade the core endpoint you are using to "https://apis.dev.pasqal.cloud/core-fast"
+- A new version of the "core" microservice, using FastAPI instead of Flask as web framework, was released in the "dev"
+  environment. If using the "dev" environment, you should upgrade the core endpoint you are using
+  to "https://apis.dev.pasqal.cloud/core-fast"
 
 ## [0.1.9] - 2023-02-07
 
@@ -315,25 +331,37 @@ Note that for backwards compatibility, the `group_id` is still exposed by the AP
 ### Changed
 
 - Moved the device_types into device module
-- Refactored configuration to be split into `BaseConfig`, `EmuSVConfig` and `EmuFreeConfig`, more device-specific configs can be added
+- Refactored configuration to be split into `BaseConfig`, `EmuSVConfig` and `EmuFreeConfig`, more device-specific
+  configs can be added
 - Refactored unit tests to use the proper Config model.
 - Updated README with the new Configuration classes.
 
 ### Added
 
-- `BaseConfig`: the base configuration class. A dataclass with the same methods as the former `Configuration` model and the `extra_config` param.
-- `EmuSVConfig`: the configuration class for `DeviceType.EMU_SV`, inherits from `BaseConfig` with the parameters formerly found on `Configuration`.
-- `EmuFreeConfig`: the configuration class for `DeviceType.EMU_FREE`, inherits from `BaseConfig` with the `with_noise` boolean parameter.
+- `BaseConfig`: the base configuration class. A dataclass with the same methods as the former `Configuration` model and
+  the `extra_config` param.
+- `EmuSVConfig`: the configuration class for `DeviceType.EMU_SV`, inherits from `BaseConfig` with the parameters
+  formerly found on `Configuration`.
+- `EmuFreeConfig`: the configuration class for `DeviceType.EMU_FREE`, inherits from `BaseConfig` with the `with_noise`
+  boolean parameter.
 
 ## [0.1.7] - 2023-01-04
 
 ### Changed
 
-Reworked the `wait` logic when [creating a batch](https://github.com/pasqal-io/pasqal-cloud/blob/dev/sdk/__init__.py#L46) or [declaring it as complete](<(https://github.com/pasqal-io/pasqal-cloud/blob/dev/sdk/batch.py#L95)>). The old `wait` has been split into
-two separate boolean kwargs `wait` and `fetch_results`. - `wait` when set to `True` still makes the python statement blocking until the batch gets assigned a termination status (e.g. `DONE`, `ERROR`, `TIMED_OUT`) but doesn't trigger fetching of results. - `fetch_results` is a boolean which when set to `True` makes the python statement blocking until the batch has a termination status and then fetches the results for all the jobs of the batch.
+Reworked the `wait` logic
+when [creating a batch](https://github.com/pasqal-io/pasqal-cloud/blob/dev/sdk/__init__.py#L46)
+or [declaring it as complete](<(https://github.com/pasqal-io/pasqal-cloud/blob/dev/sdk/batch.py#L95)>). The old `wait`
+has been split into
+two separate boolean kwargs `wait` and `fetch_results`. - `wait` when set to `True` still makes the python statement
+blocking until the batch gets assigned a termination status (e.g. `DONE`, `ERROR`, `TIMED_OUT`) but doesn't trigger
+fetching of results. - `fetch_results` is a boolean which when set to `True` makes the python statement blocking until
+the batch has a termination status and then fetches the results for all the jobs of the batch.
 
-This enables the user to wait for the results and then implement its own custom logic to retrieve results (e.g. only fetch the results for the last job of the batch).
-This also fixes a bug where the user needed an extra call after the batch creation to the `get_batch` function to retrieve results. Now results will be properly populated after batch creation when setting `fetch_results=True`.
+This enables the user to wait for the results and then implement its own custom logic to retrieve results (e.g. only
+fetch the results for the last job of the batch).
+This also fixes a bug where the user needed an extra call after the batch creation to the `get_batch` function to
+retrieve results. Now results will be properly populated after batch creation when setting `fetch_results=True`.
 
 ### Fixed
 
@@ -343,7 +371,8 @@ This is the last released version before the implementation of the changelog.
 
 ### Added
 
-See commit history before [this commit](https://github.com/pasqal-io/pasqal-cloud/commit/7c703534f55012489550f7df116f3f326e741de5).
+See commit history
+before [this commit](https://github.com/pasqal-io/pasqal-cloud/commit/7c703534f55012489550f7df116f3f326e741de5).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Introduced a new filtering system using Pydantic classes for more flexible and robust filtering options
+- Introduced a new filtering system using classes for more flexible and robust filtering options
 - Added 'get_jobs' method, a feature to retrieve a list of jobs based on 'JobFilters'
 
 ### Breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.11.0] - 2024-06-14
+## [0.11.0] - 2024-06-27
 
 ### Added
 

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -254,9 +254,6 @@ class SDK:
             filters: filters to be applied to find the jobs that will be retried
 
         Returns:
-            Batch: the new re-created batch
-
-        Returns:
             An instance of a rescheduled Batch model. The fields
             can differ from the original batch as the record
             is recreated as to prevent modifying the original batch.
@@ -272,7 +269,7 @@ class SDK:
             )
 
         try:
-            new_batch_data = self._client._rebatch(
+            new_batch_data = self._client.rebatch(
                 batch_id=id,
                 filters=filters,
             )
@@ -338,7 +335,7 @@ class SDK:
             )
 
         try:
-            response = self._client._get_jobs(
+            response = self._client.get_jobs(
                 filters=filters, pagination_params=pagination_params
             )
             jobs = response["data"]

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from getpass import getpass
-from typing import Any, Dict, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 from uuid import UUID
 
 import requests

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -241,7 +241,7 @@ class Client:
         )["data"]
         return response
 
-    def _rebatch(
+    def rebatch(
         self, batch_id: Union[UUID, str], filters: RebatchFilters
     ) -> Dict[str, Any]:
         response: Dict[str, Any] = self._authenticated_request(
@@ -251,12 +251,12 @@ class Client:
         )["data"]
         return response
 
-    def _get_jobs(
+    def get_jobs(
         self, filters: JobFilters, pagination_params: PaginationParams
     ) -> JSendPayload:
         filters_params = filters.model_dump(exclude_unset=True)
         filters_params.update(pagination_params.model_dump())
-        response: JSendPayload = self._request(
+        response: JSendPayload = self._authenticated_request(
             "GET",
             f"{self.endpoints.core}/api/v2/jobs",
             params=filters_params,

--- a/pasqal_cloud/utils/constants.py
+++ b/pasqal_cloud/utils/constants.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class JobStatus(Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    DONE = "DONE"
+    ERROR = "ERROR"
+    CANCELED = "CANCELED"

--- a/pasqal_cloud/utils/models.py
+++ b/pasqal_cloud/utils/models.py
@@ -1,0 +1,161 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_serializer, field_validator
+
+from pasqal_cloud.utils.constants import JobStatus
+
+
+class BaseFilters(BaseModel):
+    @staticmethod
+    def convert_to_list(value: Any) -> Any:
+        if not value:
+            return None
+        if isinstance(value, list):
+            return value
+        return [value]
+
+    @staticmethod
+    def convert_str_to_uuid(value: Any) -> Any:
+        if isinstance(value, str):
+            try:
+                return UUID(value)
+            except ValueError:
+                raise ValueError(f"Cannot convert {value} to UUID.")
+        return value
+
+    @field_serializer("start_date", "end_date", check_fields=False)
+    def serialize_datetime_to_isoformat(self, date: datetime) -> str:
+        return date.isoformat()
+
+
+class RebatchFilters(BaseFilters):
+    """
+    Class to provide filters for querying jobs to re-create.
+
+    Setting a value for any attribute of this class will add a filter to the query.
+
+    When using several filters at the same time, the API will return elements who pass
+    all filters at the same time:
+        - If the filter value is a single element, the API will return jobs whose
+          attribute matches the provided value.
+        - If the filter value is a list, the API will return jobs whose value for
+          this attribute is contained in that list.
+
+    Attributes:
+        id: Filter by job IDs
+        status: Filter by job statuses,
+        min_runs: Minimum number of runs.
+        max_runs: Maximum number of runs.
+        start_date: Retry jobs created at or after this datetime.
+        end_date: Retry jobs created at or before this datetime.
+    """
+
+    id: Optional[Union[List[Union[UUID, str]], Union[UUID, str]]] = None
+    status: Optional[Union[List[JobStatus], JobStatus]] = None
+    min_runs: Optional[int] = None
+    max_runs: Optional[int] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+    @field_validator("id", "status", mode="before")
+    @classmethod
+    def single_item_to_list_validator(cls, values: Dict[str, Any]) -> Any:
+        return cls.convert_to_list(values)
+
+    @field_validator("id", mode="after")
+    @classmethod
+    def str_to_uuid_validator(cls, values: Dict[str, Any]) -> Dict[str, UUID]:
+        for item in values:
+            cls.convert_str_to_uuid(item)
+        return values
+
+    @field_serializer("status", check_fields=False)
+    def status_enum_to_string(self, job_statuses: List[JobStatus]) -> List[str]:
+        return [job_status.value for job_status in job_statuses]
+
+
+class JobFilters(BaseFilters):
+    """
+    Class to provide filters for querying jobs.
+
+    Setting a value for any attribute of this class will add a filter to the query.
+
+    When using several filters at the same time, the API will return elements who pass
+    all filters at the same time:
+        - If the filter value is a single element, the API will return jobs whose
+          attribute matches the provided value.
+        - If the filter value is a list, the API will return jobs whose value for
+          this attribute is contained in that list.
+
+    Attributes:
+        id: Filter by job IDs.
+        project_id: Filter by project IDs.
+        user_id: Filter by user IDs.
+        batch_id: Filter by batch IDs.
+        status: Filter by job statuses.
+        min_runs: Minimum number of runs.
+        max_runs: Maximum number of runs.
+        errors: Filter by presence of errors.
+        start_date: Retry jobs created at or after this datetime.
+        end_date: Retry jobs created at or before this datetime.
+    """
+
+    id: Optional[Union[List[Union[UUID, str]], Union[UUID, str]]] = None
+    project_id: Optional[Union[List[Union[UUID, str]], Union[UUID, str]]] = None
+    user_id: Optional[Union[List[str], str]] = None
+    batch_id: Optional[Union[List[Union[UUID, str]], Union[UUID, str]]] = None
+    status: Optional[Union[List[JobStatus], JobStatus]] = None
+    min_runs: Optional[int] = None
+    max_runs: Optional[int] = None
+    errors: Optional[bool] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+    @field_validator("id", "project_id", "user_id", "batch_id", "status", mode="before")
+    @classmethod
+    def single_item_to_list_validator(cls, values: Dict[str, Any]) -> Any:
+        return cls.convert_to_list(values)
+
+    @field_validator("id", "project_id", "batch_id", mode="after")
+    @classmethod
+    def str_to_uuid_validator(cls, values: Dict[str, Any]) -> Dict[str, UUID]:
+        for item in values:
+            cls.convert_str_to_uuid(item)
+        return values
+
+    @field_serializer("status", check_fields=False)
+    def status_enum_to_string(self, job_statuses: List[JobStatus]) -> List[str]:
+        return [job_status.value for job_status in job_statuses]
+
+
+class PaginationParams(BaseFilters):
+    """
+    Class providing parameters for paginating query results.
+
+    Attributes:
+        offset: The starting index of the items to return (must be 0 or greater).
+        limit: The maximum number of items to return (must be greater than 0 and
+               less than or equal to 100).
+    """
+
+    offset: int = Field(default=0, strict=True, ge=0)
+    limit: int = Field(default=100, strict=True, gt=0, le=100)
+
+
+class PaginatedResponse(BaseModel):
+    """
+    Class representing a paginated response structure.
+
+    Attributes:
+        total: The total number of items matching the query.
+        offset: The starting point for the current set of paginated results.
+                It indicates the number of items skipped before the current set.
+        results: A list of items that match the query and pagination parameters
+                 provided.
+    """
+
+    total: int
+    offset: int
+    results: List[Any]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ select = [
     "PERF",
     "RUF",
 ]
-ignore = ["W191", "E111", "E114", "E117", "SIM115"]
+ignore = ["W191", "E111", "E114", "E117", "Q000", "Q001", "Q002", "Q003", "SIM115"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/fixtures/api/v2/jobs/_.GET.json
+++ b/tests/fixtures/api/v2/jobs/_.GET.json
@@ -2,18 +2,16 @@
   "code": 200,
   "data": [
     {
-      "id": "00000000-0000-0000-0000-000000000001",
-      "project_id": "00000000-0000-0000-0000-000000000001",
-      "user_id": "1",
       "batch_id": "00000000-0000-0000-0000-000000000001",
-      "created_at": "2023-01-01T12:00:00.000000",
+      "project_id": "00000000-0000-0000-0000-000000000002",
+      "created_at": "2021-11-10T15:24:38.172109",
       "errors": [
         "Error 1",
         "Error 2: Cannot connect to QPU",
         "Error 3: Matrix glitch"
       ],
-      "result": { "1001": 12, "0110": 35, "1111": 1 },
-      "runs": 15,
+      "id": "00000000-0000-0000-0000-000000022010",
+      "runs": 50,
       "status": "DONE",
       "updated_at": "2021-11-10T15:27:06.698066",
       "start_timestamp": "21636558026.698066",
@@ -21,34 +19,13 @@
       "variables": {
         "Omega_max": 14.4,
         "last_target": "q1",
-        "ts": [200, 500]
-      },
-      "origin": "AZURE"
-    },
-    {
-      "id": "00000000-0000-0000-0000-000000000002",
-      "project_id": "00000000-0000-0000-0000-000000000002",
-      "user_id": "2",
-      "batch_id": "00000000-0000-0000-0000-000000000002",
-      "created_at": "2023-01-01T13:00:00.000000",
-      "errors": [
-        "Error 3: Matrix glitch"
-      ],
-      "result": { "1001": 8, "0110": 25, "1111": 3 },
-      "runs": 18,
-      "status": "PENDING",
-      "updated_at": "2023-01-01T13:30:00.000000",
-      "start_timestamp": "1672570200.000000",
-      "end_timestamp": "1672572000.000000",
-      "variables": {
-        "Omega_max": 10.2,
-        "last_target": "q2",
-        "ts": [300, 600]
-      },
-      "origin": "CLIENT"
+        "ts": [
+          200,
+          500
+        ]
+      }
     }
   ],
   "message": "OK.",
-  "status": "success",
-  "pagination": {"total":  2, "start":  0, "end":  2}
+  "status": "success"
 }

--- a/tests/fixtures/api/v2/jobs/_.GET.json
+++ b/tests/fixtures/api/v2/jobs/_.GET.json
@@ -2,16 +2,18 @@
   "code": 200,
   "data": [
     {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "project_id": "00000000-0000-0000-0000-000000000001",
+      "user_id": "1",
       "batch_id": "00000000-0000-0000-0000-000000000001",
-      "project_id": "00000000-0000-0000-0000-000000000002",
-      "created_at": "2021-11-10T15:24:38.172109",
+      "created_at": "2023-01-01T12:00:00.000000",
       "errors": [
         "Error 1",
         "Error 2: Cannot connect to QPU",
         "Error 3: Matrix glitch"
       ],
-      "id": "00000000-0000-0000-0000-000000022010",
-      "runs": 50,
+      "result": { "1001": 12, "0110": 35, "1111": 1 },
+      "runs": 15,
       "status": "DONE",
       "updated_at": "2021-11-10T15:27:06.698066",
       "start_timestamp": "21636558026.698066",
@@ -20,9 +22,33 @@
         "Omega_max": 14.4,
         "last_target": "q1",
         "ts": [200, 500]
-      }
+      },
+      "origin": "AZURE"
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "project_id": "00000000-0000-0000-0000-000000000002",
+      "user_id": "2",
+      "batch_id": "00000000-0000-0000-0000-000000000002",
+      "created_at": "2023-01-01T13:00:00.000000",
+      "errors": [
+        "Error 3: Matrix glitch"
+      ],
+      "result": { "1001": 8, "0110": 25, "1111": 3 },
+      "runs": 18,
+      "status": "PENDING",
+      "updated_at": "2023-01-01T13:30:00.000000",
+      "start_timestamp": "1672570200.000000",
+      "end_timestamp": "1672572000.000000",
+      "variables": {
+        "Omega_max": 10.2,
+        "last_target": "q2",
+        "ts": [300, 600]
+      },
+      "origin": "CLIENT"
     }
   ],
   "message": "OK.",
-  "status": "success"
+  "status": "success",
+  "pagination": {"total":  2, "start":  0, "end":  2}
 }

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -73,7 +73,7 @@ class TestJob:
         assert (
             mock_request_exception.last_request.url
             == f"{self.sdk._client.endpoints.core}"
-            f"/api/v1/jobs/{job.id}"
+            f"/api/v2/jobs/{job.id}"
         )
 
     def test_cancel_job_self(self, mock_request: Generator[Any, Any, None], job: Job):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,7 +1,141 @@
-from pasqal_cloud import Job
+from datetime import datetime
+from typing import Any, Generator, List, Union
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from pasqal_cloud import (
+    Job,
+    JobCancellingError,
+    JobFetchingError,
+    JobFilters,
+    PaginatedResponse,
+    PaginationParams,
+    SDK,
+)
+from pasqal_cloud.utils.constants import JobStatus
+from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
+from tests.utils import build_query_params
 
 
 class TestJob:
+    @pytest.fixture(autouse=True)
+    @patch(
+        "pasqal_cloud.client.Auth0TokenProvider",
+        FakeAuth0AuthenticationSuccess,
+    )
+    def _init_sdk(self):
+        self.sdk = SDK(
+            username="me@test.com",
+            password="password",
+            project_id=str(uuid4()),
+        )
+        self.pulser_sequence = "pulser_test_sequence"
+        self.batch_id = "00000000-0000-0000-0000-000000000001"
+        self.job_id = "00000000-0000-0000-0000-000000022010"
+        self.n_job_runs = 50
+        self.job_variables = {
+            "Omega_max": 14.4,
+            "last_target": "q1",
+            "ts": [200, 500],
+        }
+        self.simple_job_args = {
+            "runs": self.n_job_runs,
+            "variables": self.job_variables,
+        }
+        self.job_result = {"1001": 12, "0110": 35, "1111": 1}
+        self.job_full_result = {
+            "counter": {"1001": 12, "0110": 35, "1111": 1},
+            "raw": ["1001", "1001", "0110", "1001", "0110"],
+        }
+
+    @pytest.mark.usefixtures("mock_request")
+    def test_get_job(self, job: Job):
+        """
+        Asserting the anticipated object is returned with
+        the mocked values when using SDK methods.
+        """
+        job_requested = self.sdk.get_job(job.id)
+        assert job_requested.id == job.id
+
+    def test_get_job_error(
+        self, job, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        When attempting to execute get_job, we receive an exception
+        which prevents any values being returned.
+        We then assert all the correct methods and urls were used.
+        """
+        with pytest.raises(JobFetchingError):
+            _ = self.sdk.get_job(job.id)
+        assert mock_request_exception.last_request.method == "GET"
+        assert (
+            mock_request_exception.last_request.url
+            == f"{self.sdk._client.endpoints.core}"
+            f"/api/v1/jobs/{job.id}"
+        )
+
+    def test_cancel_job_self(self, mock_request: Generator[Any, Any, None], job: Job):
+        """
+        After cancelling a job, we can assert that the status is CANCELED as expected
+        and that the correct methods and URLS were used.
+        """
+        job.cancel()
+        assert job.status == "CANCELED"
+        assert mock_request.last_request.method == "PUT"
+        assert (
+            mock_request.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
+        )
+
+    def test_cancel_job_self_error(
+        self, mock_request_exception: Generator[Any, Any, None], job: Job
+    ):
+        """
+        When trying to cancel a job, we assert that an exception is raised
+        while confirming the expected HTTP methods and URLs are used and that
+        the job status is still PENDING.
+        """
+        with pytest.raises(JobCancellingError):
+            job.cancel()
+        assert job.status == "PENDING"
+        assert mock_request_exception.last_request.method == "PUT"
+        assert (
+            mock_request_exception.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
+        )
+
+    def test_cancel_job_sdk(self, mock_request: Generator[Any, Any, None]):
+        """
+        After successfully executing the .cancel_job method,
+        we further validate the response object is as anticipated,
+        while confirming the expected HTTP methods and URLs are used.
+        """
+        client_rsp = self.sdk.cancel_job(self.job_id)
+        assert type(client_rsp) == Job
+        assert client_rsp.status == "CANCELED"
+        assert mock_request.last_request.method == "PUT"
+        assert (
+            mock_request.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
+        )
+
+    def test_cancel_job_sdk_error(
+        self, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        When trying to cancel a job, we assert that an exception is raised
+        while confirming the expected HTTP methods and URLs are used.
+        """
+        with pytest.raises(JobCancellingError):
+            _ = self.sdk.cancel_job(self.job_id)
+        assert mock_request_exception.last_request.method == "PUT"
+        assert (
+            mock_request_exception.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}/cancel"
+        )
+
     def test_job_instantiation_with_extra_field(self, job):
         """Instantiating a job with an extra field should not raise an error.
 
@@ -17,3 +151,199 @@ class TestJob:
         assert (
             new_job.new_field == "any_value"
         )  # The new value should be stored regardless
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            # No filters provided
+            None,
+            # Empty object
+            JobFilters(),
+            # Single UUID for id
+            JobFilters(id=UUID(int=0x1)),
+            # List of UUIDs for id
+            JobFilters(id=[UUID(int=0x1), UUID(int=0x2)]),
+            # Single string UUID for id
+            JobFilters(id=str(UUID(int=0x1))),
+            # List of string UUIDs for id
+            JobFilters(id=[str(UUID(int=0x1)), str(UUID(int=0x2))]),
+            # Single UUID for project_id
+            JobFilters(project_id=UUID(int=0x1)),
+            # List of UUIDs for project_id
+            JobFilters(project_id=[UUID(int=0x1), UUID(int=0x2)]),
+            # Single string UUID for project_id
+            JobFilters(project_id=str(UUID(int=0x1))),
+            # List of string UUIDs for project_id
+            JobFilters(project_id=[str(UUID(int=0x1)), str(UUID(int=0x2))]),
+            # Single user_id as string
+            JobFilters(user_id="1"),
+            # List of user_ids as strings
+            JobFilters(user_id=["1", "2"]),
+            # Single UUID for batch_id
+            JobFilters(batch_id=UUID(int=0x2)),
+            # List of UUIDs for batch_id
+            JobFilters(batch_id=[UUID(int=0x1), UUID(int=0x2)]),
+            # Single string UUID for batch_id
+            JobFilters(batch_id=str(UUID(int=0x1))),
+            # List of string UUIDs for batch_id
+            JobFilters(batch_id=[str(UUID(int=0x1)), str(UUID(int=0x2))]),
+            # Single status
+            JobFilters(status=JobStatus.DONE),
+            # List of statuses
+            JobFilters(status=[JobStatus.DONE, JobStatus.PENDING]),
+            # Minimum runs
+            JobFilters(min_runs=10),
+            # Maximum runs
+            JobFilters(max_runs=20),
+            # Errors flag
+            JobFilters(errors=True),
+            # Start date
+            JobFilters(start_date=datetime(2023, 1, 1)),
+            # End date
+            JobFilters(end_date=datetime(2023, 1, 1)),
+            # Combined
+            JobFilters(
+                id=[UUID(int=0x1), str(UUID(int=0x2))],
+                project_id=[UUID(int=0x1), UUID(int=0x2)],
+                user_id=["1", "2"],
+                batch_id=[UUID(int=0x1), UUID(int=0x2)],
+                status=JobStatus.DONE,
+                min_runs=10,
+                max_runs=20,
+                errors=True,
+                start_date=datetime(2023, 1, 1),
+                end_date=datetime(2023, 1, 1),
+            ),
+        ],
+    )
+    def test_get_jobs_with_filters_success(
+        self,
+        mock_request: Any,
+        filters: Union[JobFilters, None],
+    ):
+        """
+        As a user using the SDK with proper credentials,
+        I can get a list of jobs with specific filters.
+        The resulting request will retrieve the jobs that match the filters.
+        """
+        response = self.sdk.get_jobs(filters=filters)
+        assert isinstance(response, PaginatedResponse)
+        assert isinstance(response.total, int)
+        assert isinstance(response.results, List)
+        for item in response.results:
+            assert isinstance(item, Job)
+        assert mock_request.last_request.method == "GET"
+
+        # Convert filters to the appropriate format for query parameters
+        query_params = build_query_params(
+            filters.model_dump(exclude_unset=True) if filters is not None else None,
+            PaginationParams().model_dump(),
+        )
+        # Check that the correct url was requested with query params
+        assert (
+            mock_request.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v2/jobs{query_params}"
+        )
+
+    @pytest.mark.parametrize(
+        "pagination",
+        [
+            None,
+            PaginationParams(),
+            PaginationParams(limit=1),
+            PaginationParams(offset=50, limit=1),
+            PaginationParams(offset=100, limit=100),
+            PaginationParams(offset=1000, limit=100),
+        ],
+    )
+    def test_get_jobs_with_pagination_success(
+        self, mock_request: Any, pagination: PaginationParams
+    ):
+        """
+        As a user using the SDK with proper credentials,
+        I can get a list of jobs with pagination parameters.
+        The resulting request will retrieve the jobs that match
+        the pagination parameters.
+        """
+        response = self.sdk.get_jobs(pagination_params=pagination)
+        assert isinstance(response, PaginatedResponse)
+        assert isinstance(response.total, int)
+        assert isinstance(response.results, List)
+        for item in response.results:
+            assert isinstance(item, Job)
+        assert mock_request.last_request.method == "GET"
+
+        # Convert filters to the appropriate format for query parameters
+        query_params = build_query_params(
+            pagination_params=(
+                pagination.model_dump()
+                if pagination
+                else PaginationParams().model_dump()
+            )
+        )
+        # Check that the correct url was requested with query params
+        assert (
+            mock_request.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v2/jobs{query_params}"
+        )
+
+    def test_get_jobs_sdk_error(
+        self, mock_request_exception: Generator[Any, Any, None]
+    ):
+        """
+        As a user using the SDK with proper credentials,
+        if my request for getting jobs returns a status code different from 200,
+        I am faced with the JobFetchingError.
+        """
+        with pytest.raises(JobFetchingError):
+            _ = self.sdk.get_jobs()
+        assert mock_request_exception.last_request.method == "GET"
+        assert (
+            mock_request_exception.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v2/jobs?offset=0&limit=100"
+        )
+
+    def test_get_jobs_raises_value_error_on_invalid_filters(self):
+        """
+        As a user using the SDK with proper credentials,
+        if I pass a dictionary instead of JobFilters, a ValueError should be raised.
+        """
+        with pytest.raises(
+            ValueError, match="Filters needs to be a JobFilters instance"
+        ):
+            _ = self.sdk.get_jobs(filters={"min_runs": 10})
+
+    def test_get_jobs_raises_value_error_on_invalid_pagination_params(self):
+        """
+        As a user using the SDK with proper credentials,
+        if I pass a dictionary instead of PaginationParams, a ValueError should
+        be raised.
+        """
+        with pytest.raises(
+            ValueError,
+            match="Pagination parameters needs to be a PaginationParams instance",
+        ):
+            _ = self.sdk.get_jobs(pagination_params={"offset": 100, "limit": 100})
+
+    def test_get_jobs_raises_value_error_on_invalid_value_for_offset(self):
+        """
+        As a user using the SDK with proper credentials,
+        if I pass a 'from_index' inferior to 0, it raises a ValueError to the user.
+        """
+        with pytest.raises(
+            ValueError, match="Input should be greater than or equal to 0"
+        ):
+            _ = self.sdk.get_jobs(pagination_params=PaginationParams(offset=-1))
+
+    @pytest.mark.parametrize(
+        "limit",
+        [-1, 0, 101],
+    )
+    def test_get_jobs_raises_value_error_on_invalid_value_for_limit(self, limit: int):
+        """
+        As a user using the SDK with proper credentials,
+        if I pass a 'limit' inferior to 1 or superior to 100,
+        it raises a ValueError to the user.
+        """
+        with pytest.raises(ValueError, match="limit"):
+            _ = self.sdk.get_jobs(pagination_params=PaginationParams(limit=limit))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlencode
+from uuid import UUID
+
+
+def convert_to_serializable(value: Any) -> Any:
+    """Convert values to a serializable format."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (List, Tuple)):
+        return [convert_to_serializable(v) for v in value]
+    if isinstance(value, Dict):
+        return {k: convert_to_serializable(v) for k, v in value.items()}
+    return value
+
+
+def build_query_params(
+    filters: Optional[Dict[str, Any]] = None,
+    pagination_params: Optional[Dict[str, int]] = None,
+) -> str:
+    """Convert filters to a URL-encoded query parameter string.
+
+    Encode query parameters using doseq=True to handle sequences
+    correctly, it ensures that each element of a sequence
+    is treated as a separate query parameter.
+    """
+    serialised_params = {}
+    if filters:
+        serialised_params.update(convert_to_serializable(filters))
+    if pagination_params:
+        serialised_params.update(pagination_params)
+    # To avoid returning a single interrogation point without query parameters
+    return "?" + urlencode(serialised_params, doseq=True) if serialised_params else ""


### PR DESCRIPTION
### Description

This PR introduces a new method, get_jobs, for retrieving a list of jobs from the Pasqal backend using the V2 endpoint. The method utilizes 2 Pydantic class:
- JobFilters, allowing users to filter jobs without managing pagination manually
- PaginationParams, allowing users to manipulate pagination details such as the offset and the limit of jobs per page.

Additionally, similar enhancements have been applied to the rebatch method, incorporating the RebatchFilters class for filtering. This change is backward-incompatible.

Tests have been updated to match the new logic.

##### New Method: get_jobs

- Retrieves a list of jobs from the Pasqal backend.
- Filters jobs using the JobFilters and PaginationParams Pydantic classes.
- Does not return results from jobs.

##### Filtering Capabilities

Users can filter jobs based on several fields:

- id
- project_id
- user_id
- batch_id
- status
- min_runs
- max_runs
- errors
- origin
- start_date
- end_date

Note: Filtering by id__starts_with is not supported.

##### Pagination Management

Pagination is handled by the users with the class PaginationParams. It is composed of 2 fields:

- offset: An integer representing the starting index of the data to return.
- limit: An integer representing the maximum number of data entries to return.

##### Breaking Change: rebatch Method

The rebatch method now uses the RebatchFilters class for filtering, similar to get_jobs.
Users must adapt to this new filtering mechanism.

#### Remaining Tasks

Adds updated E2E tests.

#### Additional merge criteria

The E2E tests need to pass.

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
