### PR TITLE
[CLEANUP] Remove priority from Batch attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.10.0] - 2024-06-05
+## [0.9.0] - 2024-06-05
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2024-06-05
+
+### Changed
+
+- Drop priority from Batch attributes
+
 ## [0.9.0] - 2024-05-15
 
 ### Changed

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.10.0"
+__version__ = "0.9.0"

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -42,7 +42,6 @@ class Batch(BaseModel):
         - project_id: ID of the owner project of the batch.
         - id: Unique identifier for the batch.
         - user_id: Unique identifier of the user that created the batch.
-        - priority: Level of priority of the batch.
         - status: Status of the batch. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
         - webhook: Webhook where the job results are automatically sent to.
@@ -67,7 +66,6 @@ class Batch(BaseModel):
     project_id: str
     id: str
     user_id: str
-    priority: int
     status: str
     _client: Client = PrivateAttr(default=None)
     sequence_builder: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,6 @@ def batch_data_fixture() -> Dict[str, Any]:
         "project_id": "00000000-0000-0000-0000-000000000002",
         "id": "00000000-0000-0000-0000-000000000001",
         "user_id": "EQZj1ZQE",
-        "priority": 0,
         "status": "PENDING",
         "webhook": "https://example.com/webhook",
         "sequence_builder": "pulser",

--- a/tests/fixtures/test_payloads.py
+++ b/tests/fixtures/test_payloads.py
@@ -10,7 +10,6 @@ def successful_batch_payload_response() -> Dict[str, Any]:
             "device_type": "MOCK_DEVICE",
             "project_id": "00000000-0000-0000-0000-000000000001",
             "id": "00000000-0000-0000-0000-000000000001",
-            "priority": 10,
             "sequence_builder": "pulser_test_sequence",
             "status": "PENDING",
             "updated_at": "2021-11-10T15:27:44.110274",


### PR DESCRIPTION
### Description

- Remove priority from batch attributes
- Refactor tests payloads to remove priority
- Leave priority in responses as it is still sent by public-apis

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
