### PR TITLE
[DRAFT] Expose add_jobs to __init__ for use in client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ venv*
 pipfile
 pipfile.lock
 .idea/
+
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2024-06-05
+
+### Changed
+
+- Expose add_jobs and close_batch functions in the SDK interface
+- Refactor non-private methods that were prefixed with _
+- Add test coverage for new functions
+
 ## [0.9.0] - 2024-06-05
 
 ### Changed

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -260,7 +260,7 @@ class SDK:
         Returns:
             An instance of a rescheduled Batch model. The fields
             can differ from the original batch as the record
-            is recreated as to prevent modfifying the original batch.
+            is recreated as to prevent modifying the original batch.
 
         Raises:
             RebatchError if rebatch call failed.

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -275,7 +275,7 @@ class SDK:
 
     def _get_job(self, id: str) -> Dict[str, Any]:
         try:
-            return self._client._get_job(id)
+            return self._client.get_job(id)
         except HTTPError as e:
             raise JobFetchingError(e) from e
 
@@ -304,6 +304,9 @@ class SDK:
 
         Args:
             id: ID of the job.
+
+        Returns:
+            Job: The job stored in the PCS database.
         """
         try:
             job_rsp = self._client.cancel_job(id)
@@ -323,7 +326,7 @@ class SDK:
     ) -> Dict[str, Any]:
         while workload_rsp["status"] in ["PENDING", "RUNNING"]:
             time.sleep(RESULT_POLLING_INTERVAL)
-            workload_rsp = self.get_workload(id)
+            workload_rsp = self._get_workload(id)
         return workload_rsp
 
     def create_workload(

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -256,8 +256,12 @@ class SDK:
             mas_runs: retry jobs with less or as many as this amount of runs.
             start_date: retry jobs created at or after this datetime.
             end_date: retry jobs created at or before this datetime.
+
         Returns:
-            An instance of a Batch model
+            An instance of a rescheduled Batch model. The fields
+            can differ from the original batch as the record
+            is recreated as to prevent modfifying the original batch.
+
         Raises:
             RebatchError if rebatch call failed.
         """

--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -377,7 +377,7 @@ class SDK:
         Raises:
             WorkloadFetchingError: If fetching failed.
         """
-        workload_rsp = self.get_workload(id)
+        workload_rsp = self._get_workload(id)
         if wait:
             workload_rsp = self.wait_for_workload(id, workload_rsp)
         return Workload(**workload_rsp, _client=self._client)
@@ -395,7 +395,7 @@ class SDK:
             WorkloadCancelingError: If cancelation failed.
         """
         try:
-            workload_rsp = self._client._cancel_workload(id)
+            workload_rsp = self._client.cancel_workload(id)
         except HTTPError as e:
             raise WorkloadCancellingError(e) from e
         return Workload(**workload_rsp, _client=self._client)

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/pasqal_cloud/batch.py
+++ b/pasqal_cloud/batch.py
@@ -153,7 +153,7 @@ class Batch(BaseModel):
 
         """
         try:
-            batch_rsp = self._client._add_jobs(self.id, jobs)
+            batch_rsp = self._client.add_jobs(self.id, jobs)
         except HTTPError as e:
             raise JobCreationError(e) from e
         self._update_from_api_response(batch_rsp)
@@ -198,7 +198,7 @@ class Batch(BaseModel):
         the complete batch is unassigned to its running device.
         """
         try:
-            batch_rsp = self._client._complete_batch(self.id)
+            batch_rsp = self._client.complete_batch(self.id)
         except HTTPError as e:
             raise BatchSetCompleteError(e) from e
         self._update_from_api_response(batch_rsp)
@@ -212,7 +212,7 @@ class Batch(BaseModel):
     def cancel(self) -> None:
         """Cancel the current batch on the PCS."""
         try:
-            batch_rsp = self._client._cancel_batch(self.id)
+            batch_rsp = self._client.cancel_batch(self.id)
         except HTTPError as e:
             raise BatchCancellingError(e) from e
         self._update_from_api_response(batch_rsp)
@@ -220,7 +220,7 @@ class Batch(BaseModel):
     def refresh(self) -> None:
         """Fetch the batch from the API and update it in place."""
         try:
-            batch_rsp = self._client._get_batch(self.id)
+            batch_rsp = self._client.get_batch(self.id)
         except HTTPError as e:
             raise BatchFetchingError(e) from e
         self._update_from_api_response(batch_rsp)

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -149,7 +149,7 @@ class Client:
             "HTTP Client has encountered an issue it is unable to recover from."
         )
 
-    def _send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
+    def send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})
         response: Dict[str, Any] = self._request(
             "POST",
@@ -158,19 +158,19 @@ class Client:
         )["data"]
         return response
 
-    def _get_batch(self, batch_id: str) -> Dict[str, Any]:
+    def get_batch(self, batch_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "GET", f"{self.endpoints.core}/api/v1/batches/{batch_id}"
         )["data"]
         return response
 
-    def _complete_batch(self, batch_id: str) -> Dict[str, Any]:
+    def complete_batch(self, batch_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/batches/{batch_id}/complete"
         )["data"]
         return response
 
-    def _cancel_batch(self, batch_id: str) -> Dict[str, Any]:
+    def cancel_batch(self, batch_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/batches/{batch_id}/cancel"
         )["data"]
@@ -207,7 +207,7 @@ class Client:
         )["data"]
         return response
 
-    def _add_jobs(
+    def add_jobs(
         self, batch_id: str, jobs_data: Sequence[Mapping[str, Any]]
     ) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
@@ -215,19 +215,19 @@ class Client:
         )["data"]
         return response
 
-    def _get_job(self, job_id: str) -> Dict[str, Any]:
+    def get_job(self, job_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}"
         )["data"]
         return response
 
-    def _cancel_job(self, job_id: str) -> Dict[str, Any]:
+    def cancel_job(self, job_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/jobs/{job_id}/cancel"
         )["data"]
         return response
 
-    def _send_workload(self, workload_data: Dict[str, Any]) -> Dict[str, Any]:
+    def send_workload(self, workload_data: Dict[str, Any]) -> Dict[str, Any]:
         workload_data.update({"project_id": self.project_id})
         response: Dict[str, Any] = self._request(
             "POST",
@@ -236,7 +236,7 @@ class Client:
         )["data"]
         return response
 
-    def _get_workload(self, workload_id: str) -> Dict[str, Any]:
+    def get_workload(self, workload_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "GET", f"{self.endpoints.core}/api/v2/workloads/{workload_id}"
         )["data"]

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -242,7 +242,7 @@ class Client:
         )["data"]
         return response
 
-    def _cancel_workload(self, workload_id: str) -> Dict[str, Any]:
+    def cancel_workload(self, workload_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._request(
             "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"
         )["data"]

--- a/pasqal_cloud/errors.py
+++ b/pasqal_cloud/errors.py
@@ -69,14 +69,7 @@ class BatchSetCompleteError(BatchException):
     """
 
     def __init__(self, e: HTTPError) -> None:
-        super().__init__("Batch setting to complete failed", e)
-
-
-class BatchAlreadyCompleteError(BaseException):
-    """
-    Exception class raised when attempting to update an already
-    complete batch.
-    """
+        super().__init__("Unable to set batch as complete.", e)
 
 
 class RebatchError(BatchException):

--- a/pasqal_cloud/errors.py
+++ b/pasqal_cloud/errors.py
@@ -72,6 +72,13 @@ class BatchSetCompleteError(BatchException):
         super().__init__("Batch setting to complete failed", e)
 
 
+class BatchAlreadyCompleteError(BaseException):
+    """
+    Exception class raised when attempting to update an already
+    complete batch.
+    """
+
+
 class RebatchError(BatchException):
     """Exception class raised when batch retry failed."""
 

--- a/pasqal_cloud/job.py
+++ b/pasqal_cloud/job.py
@@ -64,7 +64,7 @@ class Job(BaseModel):
     def cancel(self) -> Dict[str, Any]:
         """Cancel the current job on the PCS."""
         try:
-            job_rsp = self._client._cancel_job(self.id)
+            job_rsp = self._client.cancel_job(self.id)
         except HTTPError as e:
             raise JobCancellingError(e) from e
         self.status = job_rsp.get("status", "CANCELED")

--- a/pasqal_cloud/workload.py
+++ b/pasqal_cloud/workload.py
@@ -70,7 +70,7 @@ class Workload(BaseModel):
     def cancel(self) -> Dict[str, Any]:
         """Cancel the current job on the PCS."""
         try:
-            workload_rsp = self._client._cancel_workload(self.id)
+            workload_rsp = self._client.cancel_workload(self.id)
         except HTTPError as e:
             raise WorkloadCancellingError(e) from e
         self.status = workload_rsp.get("status", "CANCELED")


### PR DESCRIPTION
### Description

We need a method of submitting Jobs to a preexisting batch exposed on the interface that's being used by pulser-pasqal. I've also included a required method to mark a batch as complete via the SDK interface.

I've also updated some small nits that weren't quite right. We've got method prefixes for methods that are clearly exported into other files.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
