### PR TITLE
[IMPROVEMENT] Add a retry mechanism when downloading job results

### DIFF
--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -105,7 +105,7 @@ class Client:
     @retry_http_error(
         max_retries=5, retry_status_code={408, 425, 429, 500, 502, 503, 504}
     )
-    def _request(
+    def _authenticated_request(
         self,
         method: str,
         url: str,
@@ -148,7 +148,7 @@ class Client:
 
         if not params:
             params = {}
-        first_page_response = self._request(
+        first_page_response = self._authenticated_request(
             method=method, url=url, payload=payload, params=params
         )
         all_items: List[Dict] = first_page_response["data"]
@@ -161,7 +161,7 @@ class Client:
         end = pagination_data["end"]
         while end < total_nb_items:
             params["offset"] = end
-            response: JSendPayload = self._request(
+            response: JSendPayload = self._authenticated_request(
                 method=method, url=url, payload=payload, params=params
             )
 
@@ -179,7 +179,7 @@ class Client:
 
     def send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "POST",
             f"{self.endpoints.core}/api/v1/batches",
             batch_data,
@@ -187,7 +187,7 @@ class Client:
         return response
 
     def get_batch(self, batch_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "GET", f"{self.endpoints.core}/api/v2/batches/{batch_id}"
         )["data"]
         return response
@@ -221,7 +221,7 @@ class Client:
         This function request a presigned-url for a specific job_id from the core API.
         Once the presigned-url is obtained, it downloads the result from S3.
         """
-        results_link = self._request(
+        results_link = self._authenticated_request(
             "GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}/results_link"
         )["data"]["results_link"]
         if results_link:
@@ -229,13 +229,13 @@ class Client:
         return None
 
     def complete_batch(self, batch_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "PUT", f"{self.endpoints.core}/api/v1/batches/{batch_id}/complete"
         )["data"]
         return response
 
     def cancel_batch(self, batch_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "PUT", f"{self.endpoints.core}/api/v1/batches/{batch_id}/cancel"
         )["data"]
         return response
@@ -264,7 +264,7 @@ class Client:
         if not isinstance(end_date, EmptyFilter):
             query_params["end_date"] = end_date.isoformat()
 
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "POST",
             f"{self.endpoints.core}/api/v1/batches/{batch_id}/rebatch",
             params=query_params,
@@ -274,26 +274,26 @@ class Client:
     def add_jobs(
         self, batch_id: str, jobs_data: Sequence[Mapping[str, Any]]
     ) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "POST", f"{self.endpoints.core}/api/v1/batches/{batch_id}/jobs", jobs_data
         )["data"]
         return response
 
     def get_job(self, job_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "GET", f"{self.endpoints.core}/api/v2/jobs/{job_id}"
         )["data"]
         return response
 
     def cancel_job(self, job_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "PUT", f"{self.endpoints.core}/api/v1/jobs/{job_id}/cancel"
         )["data"]
         return response
 
     def send_workload(self, workload_data: Dict[str, Any]) -> Dict[str, Any]:
         workload_data.update({"project_id": self.project_id})
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "POST",
             f"{self.endpoints.core}/api/v1/workloads",
             workload_data,
@@ -301,19 +301,19 @@ class Client:
         return response
 
     def get_workload(self, workload_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "GET", f"{self.endpoints.core}/api/v2/workloads/{workload_id}"
         )["data"]
         return response
 
     def cancel_workload(self, workload_id: str) -> Dict[str, Any]:
-        response: Dict[str, Any] = self._request(
+        response: Dict[str, Any] = self._authenticated_request(
             "PUT", f"{self.endpoints.core}/api/v1/workloads/{workload_id}/cancel"
         )["data"]
         return response
 
     def get_device_specs_dict(self) -> Dict[str, str]:
-        response: Dict[str, str] = self._request(
+        response: Dict[str, str] = self._authenticated_request(
             "GET", f"{self.endpoints.core}/api/v1/devices/specs"
         )["data"]
         return response

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -18,7 +18,6 @@ from getpass import getpass
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import requests
-from requests import HTTPError
 from requests.auth import AuthBase
 
 from pasqal_cloud.authentication import (
@@ -208,7 +207,7 @@ class Client:
 
     @retry_http_error(max_retries=2)
     def _download_results(self, results_link: str) -> JobResult:
-        response = requests.get(results_link)
+        response = requests.request("GET", results_link)
         response.raise_for_status()
         data = response.json()
         return JobResult(
@@ -226,10 +225,7 @@ class Client:
             "GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}/results_link"
         )["data"]["results_link"]
         if results_link:
-            try:
-                return self._download_results(results_link)
-            except HTTPError:
-                pass
+            return self._download_results(results_link)
         return None
 
     def complete_batch(self, batch_id: str) -> Dict[str, Any]:

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -216,6 +216,12 @@ class Client:
         )
 
     def get_job_results(self, job_id: str) -> Optional[JobResult]:
+        """
+        Download job result from S3.
+
+        This function request a presigned-url for a specific job_id from the core API.
+        Once the presigned-url is obtained, it downloads the result from S3.
+        """
         results_link = self._request(
             "GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}/results_link"
         )["data"]["results_link"]

--- a/pasqal_cloud/utils/retry.py
+++ b/pasqal_cloud/utils/retry.py
@@ -1,0 +1,60 @@
+import functools
+import time
+from typing import (
+    Callable,
+    Iterable,
+    Optional,
+    ParamSpec,
+    TypeVar,
+)
+
+from requests import HTTPError
+
+Param = ParamSpec("Param")
+RT = TypeVar("RT")  # return type
+
+
+def retry_http_error(
+    max_retries: int = 5, retry_status_code: Optional[Iterable[int]] = None
+) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+    """
+    Decorator to retry an HTTP call when an HTTPError is encountered.
+
+    Args:
+        max_retries: The maximum number of retry attempts
+        retry_status_codes: Specific HTTP status codes to trigger a retry.
+            - NB: If None, retries on all HTTP error status codes.
+    """
+
+    def decorator(func: Callable[..., RT]) -> Callable[..., RT]:
+        @functools.wraps(func)
+        def wrapper(*args: Param.args, **kwargs: Param.kwargs) -> RT:
+            for iteration in range(max_retries + 1):
+                try:
+                    response = func(*args, **kwargs)
+                except HTTPError as e:  # noqa:  PERF203
+                    if (
+                        e.response is None
+                        or (
+                            retry_status_code is not None
+                            and e.response.status_code not in retry_status_code
+                        )
+                        or iteration == max_retries
+                    ):
+                        raise e
+                    delay = (1 * 2) ** iteration
+                    time.sleep(delay)
+                except Exception as e:
+                    raise e
+                else:
+                    return response
+
+            # There is no scenario where we want to reach this
+            # so we can raise a generic Exception
+            raise Exception(
+                "HTTP Client has encountered an issue it is unable to recover from."
+            )
+
+        return wrapper
+
+    return decorator

--- a/pasqal_cloud/utils/retry.py
+++ b/pasqal_cloud/utils/retry.py
@@ -4,11 +4,11 @@ from typing import (
     Callable,
     Iterable,
     Optional,
-    ParamSpec,
     TypeVar,
 )
 
 from requests import HTTPError
+from typing_extensions import ParamSpec
 
 Param = ParamSpec("Param")
 RT = TypeVar("RT")  # return type

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,7 +256,7 @@ class TestSDKRetry:
         mock_request.reset_mock()
         mock_request.register_uri("GET", "http://test-domain", status_code=status_code)
         with contextlib.suppress(Exception):
-            self.sdk._client._request("GET", "http://test-domain")
+            self.sdk._client._authenticated_request("GET", "http://test-domain")
         assert len(mock_request.request_history) == 6
 
     def test_sdk_doesnt_retry_on_exceptions(
@@ -272,7 +272,7 @@ class TestSDKRetry:
         mock_request.reset_mock()
         mock_request.register_uri("GET", "http://test-domain", status_code=400)
         with contextlib.suppress(Exception):
-            self.sdk._client._request("GET", "http://test-domain")
+            self.sdk._client._authenticated_request("GET", "http://test-domain")
         assert len(mock_request.request_history) == 1
 
     def test_sdk_200_avoids_all_exception_handling(
@@ -285,7 +285,7 @@ class TestSDKRetry:
         """
         mock_request.reset_mock()
         mock_request.register_uri("GET", "http://test-domain", json={}, status_code=200)
-        self.sdk._client._request("GET", "http://test-domain")
+        self.sdk._client._authenticated_request("GET", "http://test-domain")
         assert len(mock_request.request_history) == 1
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -223,6 +223,17 @@ class TestSDKRetry:
         with patch("time.sleep"):
             yield
 
+    def test_download_results_retry_on_exception(
+        self, mock_request: Generator[Any, Any, None]
+    ):
+        mock_request.reset_mock()
+        mock_request.register_uri(
+            "GET", "http://result-link", status_code=500, text="fake-results"
+        )
+        with contextlib.suppress(Exception):
+            self.sdk._client._download_results("http://result-link")
+        assert len(mock_request.request_history) == 3
+
     @pytest.mark.parametrize("status_code", [408, 425, 429, 500, 502, 503, 504])
     def test_sdk_retry_on_exception(
         self, mock_request: Generator[Any, Any, None], status_code: int

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -226,6 +226,14 @@ class TestSDKRetry:
     def test_download_results_retry_on_exception(
         self, mock_request: Generator[Any, Any, None]
     ):
+        """
+        Test the retry logic for HTTP calls when an error status code is encountered.
+
+        This test verifies that when an HTTP request fails with an error status code,
+        the system retries the HTTP call 2 additional times, resulting in a total of
+        3 HTTP calls.
+        """
+
         mock_request.reset_mock()
         mock_request.register_uri(
             "GET", "http://result-link", status_code=500, text="fake-results"


### PR DESCRIPTION
### Description

- Add a retry decorator
- Use the decorator to enable retry when downloading job results
- Refactor _request to use the new decorator

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
