### PR TITLE
[IMPROV] Extend the retry mechanism to handle runtime exceptions

### DIFF
--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -206,7 +206,7 @@ class Client:
             # the same order as they do in the GET /batches/{id} response
         )
 
-    @retry_http_error(max_retries=2, retry_exceptions=(requests.ConnectionError,))
+    @retry_http_error(max_retries=5, retry_exceptions=(requests.ConnectionError,))
     def _download_results(self, results_link: str) -> JobResult:
         response = requests.request("GET", results_link)
         response.raise_for_status()

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -206,7 +206,7 @@ class Client:
             # the same order as they do in the GET /batches/{id} response
         )
 
-    @retry_http_error(max_retries=2)
+    @retry_http_error(max_retries=2, retry_exceptions=(requests.ConnectionError,))
     def _download_results(self, results_link: str) -> JobResult:
         response = requests.request("GET", results_link)
         response.raise_for_status()

--- a/pasqal_cloud/utils/retry.py
+++ b/pasqal_cloud/utils/retry.py
@@ -1,6 +1,6 @@
 import functools
 import time
-from typing import Callable, Iterable, Optional, TypeVar
+from typing import Callable, Iterable, Optional, Tuple, TypeVar
 
 from requests import HTTPError
 from typing_extensions import ParamSpec
@@ -12,7 +12,7 @@ RT = TypeVar("RT")  # return type
 def retry_http_error(
     max_retries: int = 5,
     retry_status_code: Optional[Iterable[int]] = None,
-    retry_exceptions: Optional[tuple[type[Exception]]] = None,
+    retry_exceptions: Optional[Tuple[type[Exception]]] = None,
 ) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
     """
     Decorator to retry an HTTP call when an HTTPError is encountered.
@@ -46,13 +46,14 @@ def retry_http_error(
                     time.sleep(delay)
                 except Exception as e:
                     if (
-                        not retry_exceptions
-                        or not isinstance(e, retry_exceptions)
-                        or iteration == max_retries
+                        retry_exceptions
+                        and isinstance(e, retry_exceptions)
+                        and iteration < max_retries
                     ):
+                        delay = (1 * 2) ** iteration
+                        time.sleep(delay)
+                    else:
                         raise e
-                    delay = (1 * 2) ** iteration
-                    time.sleep(delay)
                 else:
                     return response
 

--- a/pasqal_cloud/utils/retry.py
+++ b/pasqal_cloud/utils/retry.py
@@ -1,6 +1,6 @@
 import functools
 import time
-from typing import Callable, Iterable, Optional, Tuple, TypeVar
+from typing import Callable, Iterable, Optional, Tuple, Type, TypeVar
 
 from requests import HTTPError
 from typing_extensions import ParamSpec
@@ -12,7 +12,7 @@ RT = TypeVar("RT")  # return type
 def retry_http_error(
     max_retries: int = 5,
     retry_status_code: Optional[Iterable[int]] = None,
-    retry_exceptions: Optional[Tuple[type[Exception]]] = None,
+    retry_exceptions: Optional[Tuple[Type[Exception]]] = None,
 ) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
     """
     Decorator to retry an HTTP call when an HTTPError is encountered.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -241,7 +241,7 @@ class TestSDKRetry:
         )
         with contextlib.suppress(Exception):
             self.sdk._client._download_results("http://result-link")
-        assert len(mock_request.request_history) == 3
+        assert len(mock_request.request_history) == 6
 
     def test_download_results_retry_on_connection_error(
         self, mock_request: Generator[Any, Any, None]
@@ -264,7 +264,7 @@ class TestSDKRetry:
 
         with contextlib.suppress(requests.ConnectionError):
             self.sdk._client._download_results("http://result-link")
-        assert len(mock_request.request_history) == 3
+        assert len(mock_request.request_history) == 6
 
     @pytest.mark.parametrize("status_code", [408, 425, 429, 500, 502, 503, 504])
     def test_sdk_retry_on_exception(


### PR DESCRIPTION
### Description

Our internal e2e tests are failing due to random network issues with S3. Therefore, we have decided to extend the retry mechanism to handle exceptions, rather than relying only on HTTP status codes

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
