### PR TITLE
[FEAT] Headers - add user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.3] - 2024-08-05
+
+### Added
+
+- Introduced the `User-Agent` header.
+
 ## [0.11.2] - 2024-07-31
 
 ### Added
@@ -33,7 +39,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Expose add_jobs and close_batch functions in the SDK interface
-- Refactor non-private methods that were prefixed with _
+- Refactor non-private methods that were prefixed with \_
 - Add test coverage for new functions
 - Drop priority from Batch attributes
 
@@ -84,8 +90,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added feature to create an "open" batch.
-    - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
-    - To add jobs to an open batch, use the `add_jobs` method.
+  - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
+  - To add jobs to an open batch, use the `add_jobs` method.
 - Updated documentation to add examples to create open batches.
 - The `wait` argument now waits for all the jobs to be terminated instead of waiting for the batch to be terminated.
 

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -20,6 +20,7 @@ from uuid import UUID
 import requests
 from requests.auth import AuthBase
 
+from pasqal_cloud._version import __version__ as sdk_version 
 from pasqal_cloud.authentication import (
     Auth0TokenProvider,
     HTTPBearerAuthenticator,
@@ -34,6 +35,7 @@ from pasqal_cloud.utils.filters import (
 )
 from pasqal_cloud.utils.jsend import JobResult, JSendPayload
 from pasqal_cloud.utils.retry import retry_http_error
+
 
 TIMEOUT = 30  # client http requests timeout after 30s
 
@@ -69,6 +71,7 @@ class Client:
 
         self.authenticator = HTTPBearerAuthenticator(token_provider)
         self.project_id = project_id
+        self.user_agent = f"PasqalCloudSDK/{sdk_version}"
 
     @staticmethod
     def _make_endpoints(endpoints: Optional[Endpoints]) -> Endpoints:
@@ -123,7 +126,10 @@ class Client:
             url,
             json=payload,
             timeout=TIMEOUT,
-            headers={"content-type": "application/json"},
+            headers={
+                "content-type": "application/json", 
+                "User-Agent": self.user_agent,
+            },
             auth=self.authenticator,
             params=params,
         )


### PR DESCRIPTION
### Description

- User-Agent header in headers of all authenticated requests

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
