### PR TITLE
Allow unauthenticated users to access device specifications

### DIFF
--- a/pasqal_cloud/__init__.py
+++ b/pasqal_cloud/__init__.py
@@ -85,10 +85,6 @@ class SDK:
             auth0: Auth0Config object to define the auth0 tenant to target.
             project_id: ID of the owner project of the batch.
         """
-
-        if not project_id:
-            raise ValueError("You need to provide a project_id")
-
         self._client = Client(
             project_id=project_id,
             username=username,

--- a/tests/fixtures/api/v1/public/devices-specs/_.GET.json
+++ b/tests/fixtures/api/v1/public/devices-specs/_.GET.json
@@ -1,0 +1,12 @@
+{
+  "code": 200,
+  "data":
+  [
+    {
+      "device_type": "FRESNEL",
+      "specs": "{\"version\":\"1\",\"channels\":[],\"name\":\"device\"}"
+    }
+  ],
+  "message": "OK.",
+  "status": "success"
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,25 +106,24 @@ class TestAuthFailure(TestSDKCommonAttributes):
 
 class TestAuthInvalidClient(TestSDKCommonAttributes):
     def test_module_no_project_id(self):
+        sdk = SDK(username=self.username, password=self.password)
         with pytest.raises(
             ValueError,
             match="You need to provide a project_id",
         ):
-            SDK(
-                username=self.username,
-                password=self.password,
-            )
+            sdk.get_batch(id="fake-id")
 
     def test_module_no_user_with_password(self):
+        sdk = SDK(
+            project_id=self.project_id,
+            username=self.no_username,
+            password=self.password,
+        )
         with pytest.raises(
             ValueError,
             match="At least a username or TokenProvider object should be provided",
         ):
-            SDK(
-                project_id=self.project_id,
-                username=self.no_username,
-                password=self.password,
-            )
+            sdk.get_batch("fake-id")
 
     @patch("pasqal_cloud.client.getpass")
     def test_module_no_password(self, getpass):
@@ -163,11 +162,12 @@ class TestAuthInvalidClient(TestSDKCommonAttributes):
             )
 
     def test_authentication_no_credentials_provided(self):
+        sdk = SDK(project_id=self.project_id)
         with pytest.raises(
             ValueError,
             match="At least a username or TokenProvider object should be provided",
         ):
-            SDK(project_id=self.project_id)
+            sdk.get_batch("fake-id")
 
     @pytest.mark.filterwarnings(
         "ignore:The parameters 'endpoints' and 'auth0' are deprecated, from now use"

--- a/tests/test_device_specs.py
+++ b/tests/test_device_specs.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+import requests_mock
 
 from pasqal_cloud import SDK
 from pasqal_cloud.errors import DeviceSpecsFetchingError
@@ -43,4 +44,30 @@ class TestDeviceSpecs:
         assert (
             mock_request_exception.last_request.url
             == f"{self.sdk._client.endpoints.core}/api/v1/devices/specs"
+        )
+
+    def test_get_public_device_specs_success(self, mock_request: requests_mock.Mocker):
+        """
+        Test that the SDK client can be initiated without specifying credentials.
+        Verify that executing `get_device_specs_dict` with an unauthenticated SDK client
+        will request the public endpoint, while an authenticated user will request the
+        private endpoint.
+        """
+
+        sdk_without_auth = SDK()
+        public_device_specs_dict = sdk_without_auth.get_device_specs_dict()
+
+        assert (
+            mock_request.last_request.url
+            == f"{sdk_without_auth._client.endpoints.core}/api/v1/public/devices-specs"
+        )
+
+        internal_device_specs_dict = self.sdk.get_device_specs_dict()
+        assert (
+            mock_request.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/devices/specs"
+        )
+
+        assert (
+            public_device_specs_dict["FRESNEL"] != internal_device_specs_dict["FRESNEL"]
         )


### PR DESCRIPTION
### Description

<!-- What has changed and why has it changed -->

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
