### PR TITLE
[FEAT] Update release flow to create release and publish on merge with main

### DIFF
--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Extract version from _version.py
         id: get_version
         run: |
-          version=$(python -c "exec(open('_version.py').read()); print(__version__)")
+          version=$(python -c "exec(open('pasqal_cloud/_version.py').read()); print(__version__)")
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Get release notes from CHANGELOG.md

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -1,8 +1,9 @@
 name: Publish pasqal-cloud 📦 to PyPI and TestPyPI
+
 on:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   build-n-publish:
@@ -10,16 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
+
       - name: Install pypa/build
         run: >-
           python -m
           pip install
           build
           --user
+
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -33,7 +37,44 @@ jobs:
         with:
           password: ${{ secrets.PASQAL_CLOUD_TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PASQAL_CLOUD_PYPI_TOKEN }}
+
+  create-github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-n-publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Extract version from _version.py
+        id: get_version
+        run: |
+          version=$(python -c "exec(open('_version.py').read()); print(__version__)")
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      - name: Get release notes from CHANGELOG.md
+        run: |
+          version=${{ env.VERSION }}
+          # Adjusted awk to extract notes with custom section headings and emoji
+          notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$notes" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Display release notes
+        run: echo "${{ env.RELEASE_NOTES }}"
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          body: ${{ env.RELEASE_NOTES }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -59,8 +59,13 @@ jobs:
       - name: Get release notes from CHANGELOG.md
         run: |
           version=${{ env.VERSION }}
-          # Adjusted awk to extract notes with custom section headings and emoji
-          notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
+          # Extract notes from changelog
+          notes=$(awk -v ver="$version" '
+              BEGIN { found_version=0; }
+              /## \[/ { if (found_version) { exit } }
+              /## \['"$version"'\]/ { found_version=1; next }
+              found_version { print }
+          ' CHANGELOG.md)
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$notes" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -61,10 +61,30 @@ jobs:
           version=${{ env.VERSION }}
           # Extract notes from changelog
           notes=$(awk -v ver="$version" '
-              BEGIN { found_version=0; }
+              BEGIN { found_version=0; output_started=0; }
               /## \[/ { if (found_version) { exit } }
-              /## \['"$version"'\]/ { found_version=1; next }
-              found_version { print }
+              /## \['"$version"'\]/ {
+                  found_version=1;
+                  next
+              }
+              found_version {
+                  # Remove the _released line
+                  if ($0 ~ /^_released/) { next }
+
+                  # Remove leading ### and any additional whitespace
+                  gsub(/^### +/, "", $0);
+
+                  # Print lines, ensuring the first one does not have leading newlines
+                  if ($0 != "") {
+                      if (output_started) {
+                          print $0;  # Print subsequent lines normally
+                      } else {
+                          print $0;  # Print the first non-empty line
+                          output_started=1;  # Set the flag after printing the first line
+                          print "";  # Print a blank line after the first output
+                      }
+                  }
+              }
           ' CHANGELOG.md)
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$notes" >> $GITHUB_ENV

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -61,7 +61,7 @@ jobs:
           version=${{ env.VERSION }}
           # Extract notes from changelog
           notes=$(awk -v ver="$version" '
-              BEGIN { found_version=0; output_started=0; }
+              BEGIN { found_version=0; leading_blank=1; }
               /## \[/ { if (found_version) { exit } }
               /## \['"$version"'\]/ {
                   found_version=1;
@@ -71,18 +71,15 @@ jobs:
                   # Remove the _released line
                   if ($0 ~ /^_released/) { next }
 
-                  # Remove leading ### and any additional whitespace
-                  gsub(/^### +/, "", $0);
+                  # Remove leading ### or ## or # and any additional whitespace
+                  gsub(/^#+ +/, "", $0);
 
-                  # Print lines, ensuring the first one does not have leading newlines
+                  # Check if the line is blank
                   if ($0 != "") {
-                      if (output_started) {
-                          print $0;  # Print subsequent lines normally
-                      } else {
-                          print $0;  # Print the first non-empty line
-                          output_started=1;  # Set the flag after printing the first line
-                          print "";  # Print a blank line after the first output
-                      }
+                      print $0;  # Print the current line
+                      leading_blank=0;  # Reset leading blank flag
+                  } else if (!leading_blank) {
+                      print "";  # Print a blank line for subsequent empty lines
                   }
               }
           ' CHANGELOG.md)

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -1,4 +1,4 @@
-name: Test release notes - to delete before merge
+name: Test release notes to delete before merge
 on: pull_request
 
 jobs:

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -5,7 +5,6 @@ jobs:
   display-github-release-notes:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build-n-publish
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -22,7 +22,12 @@ jobs:
           version=${{ env.VERSION }}
           # Adjusted awk to extract notes with custom section headings and emoji
           notes=$(awk "/## \[$version\]/,/^## \[/ {if (/^## \[/) exit; if (NF) print}" CHANGELOG.md)
-          echo "Extracted notes: $notes"
+          notes=$(awk "/## \[$version\]/,/^## \[/ {if (/^## \[/) exit; print}" CHANGELOG.md)
+          if [ -z "$notes" ]; then
+            echo "No notes extracted. Check the version format in CHANGELOG.md."
+          else
+            echo "Extracted notes: $notes"
+          fi
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$notes" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get release notes from CHANGELOG.md
         run: |
           version=${{ env.VERSION }}
-          # Adjusted awk to extract notes with custom section headings and emoji
+          # Extract notes from changelog
           notes=$(awk -v ver="$version" '
               BEGIN { found_version=0; }
               /## \[/ { if (found_version) { exit } }

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -1,5 +1,5 @@
 name: Test release notes to delete before merge
-on: pull_request
+on: push
 
 jobs:
   display-github-release-notes:

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -19,6 +19,7 @@ jobs:
           version=${{ env.VERSION }}
           # Adjusted awk to extract notes with custom section headings and emoji
           notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
+          echo "Extracted notes: $notes"
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$notes" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -1,5 +1,5 @@
 name: Test release notes - to delete before merge
-on: push
+on: pull_request
 
 jobs:
   display-github-release-notes:

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -22,10 +22,30 @@ jobs:
           version=${{ env.VERSION }}
           # Extract notes from changelog
           notes=$(awk -v ver="$version" '
-              BEGIN { found_version=0; }
+              BEGIN { found_version=0; output_started=0; }
               /## \[/ { if (found_version) { exit } }
-              /## \['"$version"'\]/ { found_version=1; next }
-              found_version { print }
+              /## \['"$version"'\]/ {
+                  found_version=1;
+                  next
+              }
+              found_version {
+                  # Remove the _released line
+                  if ($0 ~ /^_released/) { next }
+
+                  # Remove leading ### and any additional whitespace
+                  gsub(/^### +/, "", $0);
+
+                  # Print lines, ensuring the first one does not have leading newlines
+                  if ($0 != "") {
+                      if (output_started) {
+                          print $0;  # Print subsequent lines normally
+                      } else {
+                          print $0;  # Print the first non-empty line
+                          output_started=1;  # Set the flag after printing the first line
+                          print "";  # Print a blank line after the first output
+                      }
+                  }
+              }
           ' CHANGELOG.md)
           echo "Extracted notes: $notes"
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Extract version from _version.py
         id: get_version
         run: |
-          version=$(python -c "exec(open('_version.py').read()); print(__version__)")
+          version=$(python -c "exec(open('pasqal_cloud/_version.py').read()); print(__version__)")
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Get release notes from CHANGELOG.md

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -22,7 +22,7 @@ jobs:
           version=${{ env.VERSION }}
           # Extract notes from changelog
           notes=$(awk -v ver="$version" '
-              BEGIN { found_version=0; output_started=0; }
+              BEGIN { found_version=0; leading_blank=1; }
               /## \[/ { if (found_version) { exit } }
               /## \['"$version"'\]/ {
                   found_version=1;
@@ -32,18 +32,15 @@ jobs:
                   # Remove the _released line
                   if ($0 ~ /^_released/) { next }
 
-                  # Remove leading ### and any additional whitespace
-                  gsub(/^### +/, "", $0);
+                  # Remove leading ### or ## or # and any additional whitespace
+                  gsub(/^#+ +/, "", $0);
 
-                  # Print lines, ensuring the first one does not have leading newlines
+                  # Check if the line is blank
                   if ($0 != "") {
-                      if (output_started) {
-                          print $0;  # Print subsequent lines normally
-                      } else {
-                          print $0;  # Print the first non-empty line
-                          output_started=1;  # Set the flag after printing the first line
-                          print "";  # Print a blank line after the first output
-                      }
+                      print $0;  # Print the current line
+                      leading_blank=0;  # Reset leading blank flag
+                  } else if (!leading_blank) {
+                      print "";  # Print a blank line for subsequent empty lines
                   }
               }
           ' CHANGELOG.md)

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -21,13 +21,13 @@ jobs:
         run: |
           version=${{ env.VERSION }}
           # Adjusted awk to extract notes with custom section headings and emoji
-          notes=$(awk "/## \[$version\]/,/^## \[/ {if (/^## \[/) exit; if (NF) print}" CHANGELOG.md)
-          notes=$(awk "/## \[$version\]/,/^## \[/ {if (/^## \[/) exit; print}" CHANGELOG.md)
-          if [ -z "$notes" ]; then
-            echo "No notes extracted. Check the version format in CHANGELOG.md."
-          else
-            echo "Extracted notes: $notes"
-          fi
+          notes=$(awk -v ver="$version" '
+              BEGIN { found_version=0; }
+              /## \[/ { if (found_version) { exit } }
+              /## \['"$version"'\]/ { found_version=1; next }
+              found_version { print }
+          ' CHANGELOG.md)
+          echo "Extracted notes: $notes"
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$notes" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -1,0 +1,28 @@
+name: Test release notes - to delete before merge
+on: push
+
+jobs:
+  display-github-release-notes:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-n-publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Extract version from _version.py
+        id: get_version
+        run: |
+          version=$(python -c "exec(open('_version.py').read()); print(__version__)")
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      - name: Get release notes from CHANGELOG.md
+        run: |
+          version=${{ env.VERSION }}
+          # Adjusted awk to extract notes with custom section headings and emoji
+          notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$notes" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Display release notes
+        run: echo "${{ env.RELEASE_NOTES }}"

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -14,11 +14,14 @@ jobs:
           version=$(python -c "exec(open('pasqal_cloud/_version.py').read()); print(__version__)")
           echo "VERSION=$version" >> $GITHUB_ENV
 
+      - name: Debug CHANGELOG.md
+        run: cat CHANGELOG.md
+
       - name: Get release notes from CHANGELOG.md
         run: |
           version=${{ env.VERSION }}
           # Adjusted awk to extract notes with custom section headings and emoji
-          notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
+          notes=$(awk "/## \[$version\]/,/^## \[/ {if (/^## \[/) exit; if (NF) print}" CHANGELOG.md)
           echo "Extracted notes: $notes"
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$notes" >> $GITHUB_ENV

--- a/.github/workflows/verify-if-secrets-were-leaked.yml
+++ b/.github/workflows/verify-if-secrets-were-leaked.yml
@@ -13,28 +13,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
-
-  display-github-release-notes:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    needs: build-n-publish
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Extract version from _version.py
-        id: get_version
-        run: |
-          version=$(python -c "exec(open('_version.py').read()); print(__version__)")
-          echo "VERSION=$version" >> $GITHUB_ENV
-
-      - name: Get release notes from CHANGELOG.md
-        run: |
-          version=${{ env.VERSION }}
-          # Adjusted awk to extract notes with custom section headings and emoji
-          notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$notes" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Display release notes
-        run: echo "${{ env.RELEASE_NOTES }}"

--- a/.github/workflows/verify-if-secrets-were-leaked.yml
+++ b/.github/workflows/verify-if-secrets-were-leaked.yml
@@ -13,3 +13,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+
+  display-github-release-notes:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-n-publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Extract version from _version.py
+        id: get_version
+        run: |
+          version=$(python -c "exec(open('_version.py').read()); print(__version__)")
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      - name: Get release notes from CHANGELOG.md
+        run: |
+          version=${{ env.VERSION }}
+          # Adjusted awk to extract notes with custom section headings and emoji
+          notes=$(awk "/## \[$version\]/, /^## \[.*\]/ {if (/^## \[.*\]/) exit; print}" CHANGELOG.md)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$notes" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Display release notes
+        run: echo "${{ env.RELEASE_NOTES }}"

--- a/.github/workflows/verify-if-secrets-were-leaked.yml
+++ b/.github/workflows/verify-if-secrets-were-leaked.yml
@@ -1,5 +1,5 @@
 name: Verify if secrets were leaked
-on: pull_request
+on: push
 
 jobs:
   scan:

--- a/.github/workflows/verify-if-secrets-were-leaked.yml
+++ b/.github/workflows/verify-if-secrets-were-leaked.yml
@@ -1,5 +1,5 @@
 name: Verify if secrets were leaked
-on: push
+on: pull_request
 
 jobs:
   scan:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.12.3] - 2024-10-02
+## [0.12.3]
+
+_released `2024-10-02`
 
 ### ✨ Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.12.3]
-_released `2024-10-02`_
+## [0.12.3] - 2024-10-02
 
 ### ✨ Added
-  - Allow unauthenticated users to access public device specifications
+
+- Allow unauthenticated users to access public device specifications
 
 ## [0.12.2] - 2024-09-11
 


### PR DESCRIPTION
### Description

- Changed publish-to-testpypi-and-pypi to create a GitHub release and push to pypi when merging to main
- Added a test action to ensure release notes are formatted properly

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
