### PR TITLE
[CI] upgrade version of setup python

### DIFF
--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -1,9 +1,6 @@
 name: Publish pasqal-cloud 📦 to PyPI and TestPyPI
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   build-n-publish:
@@ -32,16 +29,16 @@ jobs:
           --wheel
           --outdir dist/
 
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PASQAL_CLOUD_TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+      # - name: Publish distribution 📦 to Test PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PASQAL_CLOUD_TEST_PYPI_TOKEN }}
+      #     repository_url: https://test.pypi.org/legacy/
 
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PASQAL_CLOUD_PYPI_TOKEN }}
+      # - name: Publish distribution 📦 to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PASQAL_CLOUD_PYPI_TOKEN }}
 
   create-github-release:
     name: Create GitHub Release
@@ -90,13 +87,13 @@ jobs:
       - name: Display release notes
         run: echo "${{ env.RELEASE_NOTES }}"
 
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VERSION }}
-          release_name: ${{ env.VERSION }}
-          body: ${{ env.RELEASE_NOTES }}
-          draft: false
-          prerelease: false
+      # - name: Create GitHub Release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ env.VERSION }}
+      #     release_name: ${{ env.VERSION }}
+      #     body: ${{ env.RELEASE_NOTES }}
+      #     draft: false
+      #     prerelease: false

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -1,6 +1,9 @@
 name: Publish pasqal-cloud 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build-n-publish:
@@ -29,16 +32,16 @@ jobs:
           --wheel
           --outdir dist/
 
-      # - name: Publish distribution 📦 to Test PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PASQAL_CLOUD_TEST_PYPI_TOKEN }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PASQAL_CLOUD_TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
 
-      # - name: Publish distribution 📦 to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     password: ${{ secrets.PASQAL_CLOUD_PYPI_TOKEN }}
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PASQAL_CLOUD_PYPI_TOKEN }}
 
   create-github-release:
     name: Create GitHub Release
@@ -87,13 +90,13 @@ jobs:
       - name: Display release notes
         run: echo "${{ env.RELEASE_NOTES }}"
 
-      # - name: Create GitHub Release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: ${{ env.VERSION }}
-      #     release_name: ${{ env.VERSION }}
-      #     body: ${{ env.RELEASE_NOTES }}
-      #     draft: false
-      #     prerelease: false
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          body: ${{ env.RELEASE_NOTES }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install pypa/build
         run: >-

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Install pypa/build
         run: >-


### PR DESCRIPTION
### Description

- Use v5 of setup-python in build and publish stage

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
