### PR TITLE
[CI] Add GitHub action for auto-publishing docs

### DIFF
--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -1,0 +1,28 @@
+name: Publish MkDocs documentation to gh-pages
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: doc-publish-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            doc-publish-
+      - run: pip install .[docs]
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
### Description

This adds a GitHub Action to automatically update the MkDocs-based documentation site when the repo is updated:

This uses [this recipe](https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions) with the following changes:
  - restrict the trigger condition to pushes on the `main` branch (we don't use `master`) 
  - replace `pip install mkdocs-material` by `pip install .[docs]` to install all doc dependencies listed in `setup.py`
  - change the action name and the cache key prefix for something more explicit 

It uses of the [built-in `mkdocs gh-pages` command](https://www.mkdocs.org/user-guide/deploying-your-docs/#project-pages) that builds and push by default to `gh-pages` from another branch with doc sources.

Tested locally with [act](https://nektosact.com/), everything worked fine.

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `_version.py` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
