### PR TITLE
[FIX] invalid path in yaml file

### DIFF
--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Extract version from _version.py
         id: get_version
         run: |
-          version=$(python -c "exec(open('pasqal_cloud/pasqal-cloud/_version.py').read()); print(__version__)")
+          version=$(python -c "exec(open('pasqal-cloud/pasqal_cloud/_version.py').read()); print(__version__)")
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Get release notes from CHANGELOG.md


### PR DESCRIPTION
### Description

Small error in a path value causing a CI check to fail. Since merging two repos, the application path is 1 directory deeper, this should fix it.

```
Run version=$(python -c "exec(open('pasqal_cloud/_version.py').read()); print(__version__)")
Traceback (most recent call last):
  File "<string>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory: 'pasqal_cloud/_version.py'
Error: Process completed with exit code 1.
```

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
