### PR TITLE
[FEAT] Add support for backend_configurations

### DIFF
--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -159,7 +159,6 @@ class SDK:
     def user_token(self) -> Union[str, None]:
         return self._client.user_token()
 
-
     def _get_batch(
         self,
         id: str,
@@ -177,6 +176,7 @@ class SDK:
         open: Optional[bool] = None,
         emulator: Optional[EmulatorType] = None,
         configuration: Optional[BaseConfig] = None,
+        backend_configuration: Optional[str] = None,
         wait: bool = False,
         fetch_results: bool = False,
     ) -> Batch:
@@ -246,6 +246,11 @@ class SDK:
         # it's requested
         if configuration:
             req.update({"configuration": configuration.to_dict()})  # type: ignore[dict-item]
+
+        # The backend_configuration is only added if
+        # a value is provided
+        if backend_configuration:
+            req.update({"backend_configuration": backend_configuration})
 
         try:
             batch_rsp = self._client.send_batch(req)

--- a/pasqal-cloud/pasqal_cloud/batch.py
+++ b/pasqal-cloud/pasqal_cloud/batch.py
@@ -43,7 +43,7 @@ class Batch(BaseModel):
         status: Status of the batch. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
         _client: A Client instance to connect to PCS.
-        _ordered_jobs: List of all the jobs added to the batch,
+        ordered_jobs: List of all the jobs added to the batch,
             ordered by creation time.
         jobs_count: Number of jobs added to the batch.
         jobs_count_per_status: Number of jobs per status.
@@ -51,9 +51,12 @@ class Batch(BaseModel):
         start_datetime: Timestamp of the time the batch was sent to the QPU.
         end_datetime: Timestamp of when the batch process was finished.
         device_status: Status of the device where the batch is running.
-        parent_id: ID from previous batc if a batch was resubmitted for execution.
+        parent_id: ID from previous batch if a batch was resubmitted for execution.
         configuration: Further configuration for certain emulators.
-        backend_configuration: serialised config object for emulation runtimes.
+        backend_configuration: serialised config object for emulation runtimes. This is
+            a configuration from the pulser library that can be used on certain
+            backend emulator types. It must be in the form of an
+            abstract representation/encoded string.
         jobs (deprecated): Dictionary of all the jobs added to the batch.
         sequence_builder: Pulser sequence of the batch.
     """

--- a/pasqal-cloud/pasqal_cloud/batch.py
+++ b/pasqal-cloud/pasqal_cloud/batch.py
@@ -42,18 +42,20 @@ class Batch(BaseModel):
         user_id: Unique identifier of the user that created the batch.
         status: Status of the batch. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
-        webhook: Webhook where the job results are automatically sent to.
         _client: A Client instance to connect to PCS.
-        sequence_builder: Pulser sequence of the batch.
-        start_datetime: Timestamp of the time the batch was sent to the QPU.
-        end_datetime: Timestamp of when the batch process was finished.
-        device_status: Status of the device where the batch is running.
-        jobs (deprecated): Dictionary of all the jobs added to the batch.
-        ordered_jobs: List of all the jobs added to the batch,
+        _ordered_jobs: List of all the jobs added to the batch,
             ordered by creation time.
         jobs_count: Number of jobs added to the batch.
         jobs_count_per_status: Number of jobs per status.
+        webhook: Webhook where the job results are automatically sent to.
+        start_datetime: Timestamp of the time the batch was sent to the QPU.
+        end_datetime: Timestamp of when the batch process was finished.
+        device_status: Status of the device where the batch is running.
+        parent_id: ID from previous batc if a batch was resubmitted for execution.
         configuration: Further configuration for certain emulators.
+        backend_configuration: serialised config object for emulation runtimes.
+        jobs (deprecated): Dictionary of all the jobs added to the batch.
+        sequence_builder: Pulser sequence of the batch.
     """
 
     open: bool
@@ -75,6 +77,7 @@ class Batch(BaseModel):
     device_status: Optional[str] = None
     parent_id: Optional[str] = None
     configuration: Union[BaseConfig, Dict[str, Any], None] = None
+    backend_configuration: Optional[str] = None
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 

--- a/tests/fixtures/api/v1/batches/00000000-0000-0000-0000-000000000001/jobs/_.POST.json
+++ b/tests/fixtures/api/v1/batches/00000000-0000-0000-0000-000000000001/jobs/_.POST.json
@@ -14,6 +14,7 @@
     "user_id": "EQZj1ZQE",
     "webhook": "10.0.1.5",
     "configuration": { "dt": 10.0, "precision": "normal" },
+    "backend_configuration":"i-am-a-serialised-configuration",
     "start_datetime": "2023-03-23T10:42:27.611384+00:00",
     "end_datetime": "2023-03-23T10:42:27.611384+00:00",
     "jobs": [

--- a/tests/fixtures/api/v1/batches/00000000-0000-0000-0000-000000000002/jobs/_.POST.json
+++ b/tests/fixtures/api/v1/batches/00000000-0000-0000-0000-000000000002/jobs/_.POST.json
@@ -14,6 +14,7 @@
     "user_id": "EQZj1ZQE",
     "webhook": "10.0.1.5",
     "configuration": { "dt": 10.0, "precision": "normal" },
+    "backend_configuration":"i-am-a-serialised-configuration",
     "start_datetime": "2023-03-23T10:42:27.611384+00:00",
     "end_datetime": "2023-03-23T10:42:27.611384+00:00",
     "jobs": [

--- a/tests/fixtures/api/v1/batches/_.POST.json
+++ b/tests/fixtures/api/v1/batches/_.POST.json
@@ -14,6 +14,7 @@
     "user_id": "EQZj1ZQE",
     "webhook": "10.0.1.5",
     "configuration": { "dt": 10.0, "precision": "normal" },
+    "backend_configuration":"i-am-a-serialised-configuration",
     "start_datetime": "2023-03-23T10:42:27.611384+00:00",
     "end_datetime": "2023-03-23T10:42:27.611384+00:00",
     "jobs": [

--- a/tests/fixtures/api/v2/batches/00000000-0000-0000-0000-000000000001/jobs/_.POST.json
+++ b/tests/fixtures/api/v2/batches/00000000-0000-0000-0000-000000000001/jobs/_.POST.json
@@ -14,6 +14,7 @@
     "user_id": "EQZj1ZQE",
     "webhook": "10.0.1.5",
     "configuration": { "dt": 10.0, "precision": "normal" },
+    "backend_configuration":"i-am-a-serialised-configuration",
     "start_datetime": "2023-03-23T10:42:27.611384+00:00",
     "end_datetime": "2023-03-23T10:42:27.611384+00:00",
     "jobs": [

--- a/tests/fixtures/api/v2/batches/00000000-0000-0000-0000-000000000002/jobs/_.POST.json
+++ b/tests/fixtures/api/v2/batches/00000000-0000-0000-0000-000000000002/jobs/_.POST.json
@@ -14,6 +14,7 @@
     "user_id": "EQZj1ZQE",
     "webhook": "10.0.1.5",
     "configuration": { "dt": 10.0, "precision": "normal" },
+    "backend_configuration":"i-am-a-serialised-configuration",
     "start_datetime": "2023-03-23T10:42:27.611384+00:00",
     "end_datetime": "2023-03-23T10:42:27.611384+00:00",
     "jobs": [


### PR DESCRIPTION
### Description

Add argument to enable backend_configurations in the SDK. These are serialised config objects from Pulser/Corresponding emulation library.

An example will be released in our docs alongside this request.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
