### PR TITLE
[FIX] Update pulser-pasqal test to account for new backend check in pulser 1.5.2

### DIFF
--- a/tests/test_pulser_pasqal.py
+++ b/tests/test_pulser_pasqal.py
@@ -463,6 +463,17 @@ def test_emulators_init(fixt, seq, emu_cls, monkeypatch):
         emu_cls(seq, RemoteConnection())
 
     # With mimic_qpu=True
+    with pytest.raises(ValueError, match="'sequence' should not be empty"):
+        emu_cls(
+            seq.switch_device(virtual_device),
+            fixt.pasqal_cloud,
+            mimic_qpu=True,
+        )
+
+    # Add a delay so that it's no longer empty
+    seq.declare_channel("rydberg_global", "rydberg_global")
+    seq.delay(100, "rydberg_global")
+
     with pytest.raises(TypeError, match="must be a real device"):
         emu_cls(
             seq.switch_device(virtual_device),


### PR DESCRIPTION
### Description

`Backend.validate_sequence()` now checks that the sequence is not empty, so I'm including that in `test_pulser_pasqal.py`.

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
