### PR TITLE
[FIX] CI fix for main

### DIFF
--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -48,10 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Extract version from _version.py
+      - name: Extract version from VERSION.txt
         id: get_version
         run: |
-          version=$(python -c "exec(open('pasqal-cloud/pasqal_cloud/_version.py').read()); print(__version__)")
+          version=$(cat VERSION.txt)
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Get release notes from CHANGELOG.md


### PR DESCRIPTION
### Description

Looks like a Python script can't execute because of a dunder property being absent in the environment its executed. This can apparently happen when using REPLs or notebooks so maybe it's a similar problem with the Github Action.

We should be able to just use a cat command to read the file though.

Error popping up was `NameError: name '__file__' is not defined`

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
