### PR TITLE
[CI] Pip install in the pasqal cloud directory

### DIFF
--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -25,4 +25,5 @@ jobs:
           restore-keys: |
             doc-publish-
       - run: pip install .[docs]
+        working-directory: pasqal-cloud
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
### Description

The doc publish actions was failing because pip dependencies were not installed from the right directory. This MR should fix it. I have tested by changing the rules to publish from this branch and confirmed it works fine. 

For example the tags doc section is now available [here](https://pasqal-io.github.io/pasqal-cloud/usage/batches_jobs/#set-tags-to-batches).