### PR TITLE
[FIX] Get rid of unsupported dependencies section in pyproject.toml

### DIFF
--- a/pasqal-cloud/pyproject.toml
+++ b/pasqal-cloud/pyproject.toml
@@ -1,11 +1,3 @@
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
-
-dependencies = [
-    "auth0-python >= 3.23.1, <4.0.0",
-    "requests>=2.25.1, <3.0.0",
-    "pyjwt[crypto]>=2.5.0, <3.0.0",
-    "pydantic >= 2.6.0, <3.0.0",
-    "requests-mock==1.12.1",
-]


### PR DESCRIPTION
### Description

e2e tests installation for the dev branch is broken because of this newly introduced section in the pyproject.toml. This MR removes it