### PR TITLE
[FEAT] Enable import of EmuFreeBackendV2 from pulser_pasqal

### DIFF
--- a/pulser-pasqal/pulser_pasqal/__init__.py
+++ b/pulser-pasqal/pulser_pasqal/__init__.py
@@ -16,13 +16,18 @@
 from pasqal_cloud import BaseConfig, EmulatorType, Endpoints  # noqa: F401
 
 from pulser_pasqal._version import __version__ as __version__
-from pulser_pasqal.backends import EmuFreeBackend, EmuMPSBackend, EmuTNBackend, EmuFreeBackendV2
+from pulser_pasqal.backends import (
+    EmuFreeBackend,
+    EmuMPSBackend,
+    EmuTNBackend,
+    EmuFreeBackendV2,
+)
 from pulser_pasqal.ovh import OVHConnection
 from pulser_pasqal.pasqal_cloud import PasqalCloud
 
 __all__ = [
     "EmuFreeBackend",
-    "EmuFreeBackendV2"
+    "EmuFreeBackendV2",
     "EmuTNBackend",
     "PasqalCloud",
     "EmuMPSBackend",

--- a/pulser-pasqal/pulser_pasqal/__init__.py
+++ b/pulser-pasqal/pulser_pasqal/__init__.py
@@ -16,12 +16,13 @@
 from pasqal_cloud import BaseConfig, EmulatorType, Endpoints  # noqa: F401
 
 from pulser_pasqal._version import __version__ as __version__
-from pulser_pasqal.backends import EmuFreeBackend, EmuMPSBackend, EmuTNBackend
+from pulser_pasqal.backends import EmuFreeBackend, EmuMPSBackend, EmuTNBackend, EmuFreeBackendV2
 from pulser_pasqal.ovh import OVHConnection
 from pulser_pasqal.pasqal_cloud import PasqalCloud
 
 __all__ = [
     "EmuFreeBackend",
+    "EmuFreeBackendV2"
     "EmuTNBackend",
     "PasqalCloud",
     "EmuMPSBackend",

--- a/pulser-pasqal/pulser_pasqal/__init__.py
+++ b/pulser-pasqal/pulser_pasqal/__init__.py
@@ -18,9 +18,9 @@ from pasqal_cloud import BaseConfig, EmulatorType, Endpoints  # noqa: F401
 from pulser_pasqal._version import __version__ as __version__
 from pulser_pasqal.backends import (
     EmuFreeBackend,
+    EmuFreeBackendV2,
     EmuMPSBackend,
     EmuTNBackend,
-    EmuFreeBackendV2,
 )
 from pulser_pasqal.ovh import OVHConnection
 from pulser_pasqal.pasqal_cloud import PasqalCloud


### PR DESCRIPTION
### Description

EmuFreeBackendV2 is added to the __init__ of pulser_pasqal. This enables to import it with pulser_pasqal.EmuFreeBackendV2, just like the deprecated pulser_pasqal.EmuFreeBackend. We also rely on this to build the documentation in pulser.

#### Related PRs in other projects (PASQAL developers only)

Import is currently failing in https://github.com/pasqal-io/Pulser/pull/925

#### Versioning (PASQAL developers only)

TBD: Do we need a hotfix ? Have to check how urgent it is at the pulser level.
