### PR TITLE
[DEPS] Bump pulser min version to 1.4

### DIFF
--- a/pulser-pasqal/setup.py
+++ b/pulser-pasqal/setup.py
@@ -58,7 +58,7 @@ setup(
     url="https://github.com/pasqal-io/pasqal-cloud",
     install_requires=[
         f"pasqal-cloud == {__version__}",
-        "pulser-core >= 1.3",
+        "pulser-core >= 1.4",
         "backoff ~= 2.2",
     ],
 )


### PR DESCRIPTION
Bump min pulser-core version to 1.4 in pulser-pasqal since it relies on features introduced in 1.4.

See https://github.com/pasqal-io/pasqal-cloud/issues/208

