### PR TITLE
[FIX] Remove hard-coded references to FRESNEL for multi qpu support

### DIFF
--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -190,7 +190,7 @@ class SDK:
         self,
         emulator: Optional[EmulatorType],
         device_type: Optional[DeviceTypeName],
-    ) -> DeviceTypeName:
+    ) -> Optional[DeviceTypeName]:
         if emulator is not None and device_type is not None:
             raise InvalidDeviceTypeSet
         if emulator is not None:
@@ -201,8 +201,6 @@ class SDK:
                 stacklevel=2,
             )
             return DeviceTypeName(str(emulator))
-        if emulator is None and device_type is None:
-            return DeviceTypeName.FRESNEL
         return device_type
 
     def _validate_open(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def mock_service_response(request, service_name: str):
     with open(json_path) as json_file:
         result = json.load(json_file)
         if path == "batches" and data:
-            result["data"]["device_type"] = data["device_type"]
+            result["data"]["device_type"] = data["device_type"] or "FRESNEL"
             if not data.get("configuration"):
                 result["data"]["configuration"] = None
 


### PR DESCRIPTION
### Description

Bug reported by internal user which prevents submitting with a QPUBackend to a non-Fresnel QPU.

I tested in preprod using this branch and was able to submit to FC1.