### PR TITLE
[DEPRECATION] Deprecate EMU_TN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ venv*
 pipfile
 pipfile.lock
 .idea/
+.venv
+.DS_Store
 
 .vscode
 

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -203,6 +203,20 @@ class SDK:
             return DeviceTypeName(str(emulator))
         return device_type
 
+    def _validate_device_type_choice(
+        self, device_type: Optional[DeviceTypeName]
+    ) -> None:
+        if not device_type:
+            return
+
+        if device_type == DeviceTypeName.EMU_TN:
+            warn(
+                "EMU_TN is deprecated and will be removed in a future"
+                " release. Use EMU_MPS instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
     def _validate_open(
         self,
         complete: Optional[bool],
@@ -267,6 +281,8 @@ class SDK:
         """
         device_type = self._validate_device_type(emulator, device_type)
         open = self._validate_open(complete, open)
+
+        self._validate_device_type_choice(device_type)
 
         if fetch_results:
             warn(

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -171,6 +171,25 @@ class TestBatch:
         assert mock_request.last_request.method == "GET"
         assert not batch.open
 
+    def test_create_batch_with_emu_tn_raises_warning(
+        self, mock_request: requests_mock.mocker.Mocker
+    ):
+        """
+        Test that using emulator at batch definition is still accepted but will
+        trigger a deprecation warning.
+        """
+        with pytest.warns(DeprecationWarning):
+            batch = self.sdk.create_batch(
+                serialized_sequence=self.pulser_sequence,
+                jobs=[self.simple_job_args],
+                device_type=DeviceTypeName.EMU_TN,
+                open=True,
+            )
+        assert batch.id == self.batch_id
+        assert mock_request.last_request.method == "POST"
+        assert batch.sequence_builder == self.pulser_sequence
+        assert mock_request.last_request.method == "GET"
+
     def test_batch_create_exception(
         self, mock_request_exception: requests_mock.mocker.Mocker
     ):


### PR DESCRIPTION
### Description

Added deprecation warning for EMU_TN device_type.
Added unit test.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
