### PR TITLE
[DEP]: replace backoff dependency with tenacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next release
+
+### pasqal-cloud
+
+* Replace backoff as unmaintained anymore by tenacity
+
 ## [0.22.0]
 
 ### pasqal-cloud

--- a/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
+++ b/pulser-pasqal/pulser_pasqal/pasqal_cloud.py
@@ -19,8 +19,8 @@ import logging
 from dataclasses import fields
 from typing import Any, Mapping, Type, cast
 
-import backoff
 import pasqal_cloud
+import tenacity
 from pasqal_cloud.device import BaseConfig, EmuFreeConfig, EmuTNConfig
 from pasqal_cloud.job import CreateJob
 from pulser import Sequence
@@ -45,8 +45,11 @@ EMU_TYPE_TO_CONFIG: dict[pasqal_cloud.EmulatorType, Type[BaseConfig]] = {
 
 MAX_CLOUD_ATTEMPTS = 5
 
-backoff_decorator = backoff.on_exception(
-    backoff.fibo, Exception, max_tries=MAX_CLOUD_ATTEMPTS, max_value=60
+
+retry = tenacity.retry(
+    wait=tenacity.wait_exponential(multiplier=1, max=60),
+    stop=tenacity.stop_after_attempt(MAX_CLOUD_ATTEMPTS),
+    reraise=True,
 )
 
 
@@ -116,7 +119,7 @@ class PasqalCloud(RemoteConnection):
         # batch we just created otherwise, create a new one with
         #  _sdk_connection.create_batch()
         if batch_id:
-            submit_jobs_fn = backoff_decorator(self._sdk_connection.add_jobs)
+            submit_jobs_fn = retry(self._sdk_connection.add_jobs)
             old_job_ids = self._get_job_ids(batch_id)
             batch = submit_jobs_fn(
                 batch_id,
@@ -128,7 +131,7 @@ class PasqalCloud(RemoteConnection):
                 if job_id not in old_job_ids
             ]
         else:
-            create_batch_fn = backoff_decorator(self._sdk_connection.create_batch)
+            create_batch_fn = retry(self._sdk_connection.create_batch)
             batch = create_batch_fn(
                 serialized_sequence=sequence.to_abstract_repr(),
                 jobs=job_params,
@@ -142,7 +145,7 @@ class PasqalCloud(RemoteConnection):
             new_job_ids = self._get_job_ids(batch.id)
         return self.get_results(batch_id=batch.id, job_ids=new_job_ids)
 
-    @backoff_decorator
+    @retry
     def fetch_available_devices(self) -> dict[str, Device]:
         """Fetches the devices available through this connection."""
         abstract_devices = self._sdk_connection.get_device_specs_dict()
@@ -196,7 +199,7 @@ class PasqalCloud(RemoteConnection):
     def _query_job_progress(
         self, batch_id: str
     ) -> Mapping[str, tuple[JobStatus, Results | None]]:
-        get_batch_fn = backoff_decorator(self._sdk_connection.get_batch)
+        get_batch_fn = retry(self._sdk_connection.get_batch)
         batch = get_batch_fn(id=batch_id)
 
         assert isinstance(batch.sequence_builder, str)
@@ -238,13 +241,13 @@ class PasqalCloud(RemoteConnection):
             results[job.id] = (JobStatus[job.status], None)
         return results
 
-    @backoff_decorator
+    @retry
     def _get_batch_status(self, batch_id: str) -> BatchStatus:
         """Gets the status of a batch from its ID."""
         batch = self._sdk_connection.get_batch(id=batch_id)
         return BatchStatus[batch.status]
 
-    @backoff_decorator
+    @retry
     def _get_job_ids(self, batch_id: str) -> list[str]:
         """Gets all the job IDs within a batch."""
         batch = self._sdk_connection.get_batch(id=batch_id)

--- a/pulser-pasqal/setup.py
+++ b/pulser-pasqal/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         f"pasqal-cloud == {__version__}",
         "pulser-core >= 1.6",
-        "backoff ~= 2.2",
+        "tenacity ~= 8.5",
     ],
 )
 


### PR DESCRIPTION
### Description

backoff library isn't maintained anymore so we had to find a replacement for it. tenacity is very popular one.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
