### PR TITLE
[CI/CD]: trigger publish workflows on tag push instead of push to main

### DIFF
--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -10,6 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Verify tag matches VERSION.txt
+        run: |
+          # strips refs/tags/ prefix from GITHUB_REF
+          tag="${GITHUB_REF#refs/tags/}"
+          version=$(cat VERSION.txt)
+          if [ "$tag" != "$version" ]; then
+            echo "Tag '$tag' does not match VERSION.txt '$version'"
+            exit 1
+          fi
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]

--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -1,8 +1,8 @@
 name: Publish MkDocs documentation to gh-pages
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "*"
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -2,8 +2,8 @@ name: Publish pasqal-cloud 📦 to PyPI and TestPyPI
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "*"
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-testpypi-and-pypi.yml
+++ b/.github/workflows/publish-to-testpypi-and-pypi.yml
@@ -15,6 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Verify tag matches VERSION.txt
+        run: |
+          # strips refs/tags/ prefix from GITHUB_REF
+          tag="${GITHUB_REF#refs/tags/}"
+          version=$(cat VERSION.txt)
+          if [ "$tag" != "$version" ]; then
+            echo "Tag '$tag' does not match VERSION.txt '$version'"
+            exit 1
+          fi
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
### Description

Change release trigger from push on main branch to tags push instead.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
