### PR TITLE
chore: mark every exports as deprecated and rename classes for clarity (software/sw-platform#602)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
-files =
-    pasqal-cloud/pasqal_cloud,
-    pulser-pasqal/pulser_pasqal
+packages = pasqal_cloud
+mypy_path = pasqal-cloud
+explicit_package_bases = true
 strict=true
 warn_return_any = true
 show_error_codes = true

--- a/pasqal-cloud/examples/target_fr_prod.py
+++ b/pasqal-cloud/examples/target_fr_prod.py
@@ -1,8 +1,8 @@
-from pasqal_cloud import SDK
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 
 username = ""
 project_id = "<project-uuid>"
 
-sdk = SDK(username=username, project_id=project_id, region="fr")
+sdk = PasqalCloudClient(username=username, project_id=project_id, region="fr")
 
 sdk.get_batches()

--- a/pasqal-cloud/examples/target_sa_prod.py
+++ b/pasqal-cloud/examples/target_sa_prod.py
@@ -1,8 +1,8 @@
-from pasqal_cloud import SDK
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 
 username = ""
 project_id = "<project-uuid>"
 
-sdk = SDK(username=username, project_id=project_id, region="sa")
+sdk = PasqalCloudClient(username=username, project_id=project_id, region="sa")
 
 sdk.get_batches()

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -38,4 +38,10 @@ def __getattr__(name: str) -> Any:
     """
     from pasqal_cloud._deprecations import __getattr__ as _dep_getattr
 
-    return _dep_getattr(name)
+    result = _dep_getattr(name)
+
+    # Cache the result on the module so subsequent lookups don't
+    # re-enter __getattr__ (avoids the double-call on `from X import Y`).
+    globals()[name] = result
+
+    return result

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 from typing import Any
 
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 from pasqal_cloud.ovh import OVHConnection
 from pasqal_cloud.backends import EmuMPSBackend, EmuSVBackend, EmuFreeBackend
 
 # Public API — only these two are the intended top-level exports.
 __all__ = [
-    "PasqalCloud",
+    "PasqalCloudConnection",
     "OVHConnection",
     "EmuMPSBackend",
     "EmuSVBackend",

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -11,53 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any
+
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.ovh import OVHConnection
+from pasqal_cloud.backends import EmuMPSBackend, EmuSVBackend, EmuFreeBackend
+
+# Public API — only these two are the intended top-level exports.
 __all__ = [
-    "AUTH0_CONFIG",
-    "Auth0Conf",
-    "BaseConfig",
-    "Batch",
-    "BatchCancellationResponse",
-    "BatchCancellingError",
-    "BatchClosingError",
-    "BatchCreationError",
-    "BatchFetchingError",
-    "BatchFilters",
-    "BatchSetTagsError",
-    "BatchStatus",
-    "CancelJobFilters",
-    "Client",
-    "CreateJob",
-    "DeviceSpecsFetchingError",
-    "DeviceTypeName",
-    "EmulatorType",
-    "Endpoints",
-    "InvalidDeviceTypeSet",
-    "Job",
-    "JobCancellationResponse",
-    "JobCancellingError",
-    "JobCreationError",
-    "JobFetchingError",
-    "JobFilters",
-    "JobStatus",
-    "OnlyCompleteOrOpenCanBeSet",
-    "PASQAL_ENDPOINTS",
-    "PaginatedResponse",
-    "PaginationParams",
-    "Project",
-    "ProjectFetchingError",
-    "ProjectNotFoundError",
-    "QueuePriority",
-    "RESULT_POLLING_INTERVAL",
-    "RebatchError",
-    "RebatchFilters",
-    "Region",
-    "SDK",
-    "TokenProvider",
-    "TokenProviderConf",
-    "Workload",
-    "WorkloadCancellingError",
-    "WorkloadCreationError",
-    "WorkloadFetchingError",
     "PasqalCloud",
     "OVHConnection",
     "EmuMPSBackend",
@@ -65,49 +26,16 @@ __all__ = [
     "EmuFreeBackend",
 ]
 
-from pasqal_cloud.authentication import TokenProvider
-from pasqal_cloud.batch import RESULT_POLLING_INTERVAL, Batch
-from pasqal_cloud.client import Client
-from pasqal_cloud.device import BaseConfig, DeviceTypeName, EmulatorType
-from pasqal_cloud.endpoints import AUTH0_CONFIG, PASQAL_ENDPOINTS, Auth0Conf
-from pasqal_cloud.endpoints import Endpoints as Endpoints
-from pasqal_cloud.endpoints import Region, TokenProviderConf
-from pasqal_cloud.errors import (
-    BatchCancellingError,
-    BatchClosingError,
-    BatchCreationError,
-    BatchFetchingError,
-    BatchSetTagsError,
-    DeviceSpecsFetchingError,
-    InvalidDeviceTypeSet,
-    JobCancellingError,
-    JobCreationError,
-    JobFetchingError,
-    OnlyCompleteOrOpenCanBeSet,
-    ProjectFetchingError,
-    ProjectNotFoundError,
-    RebatchError,
-    WorkloadCancellingError,
-    WorkloadCreationError,
-    WorkloadFetchingError,
-)
-from pasqal_cloud.job import CreateJob, Job
-from pasqal_cloud.project import Project
-from pasqal_cloud.sdk import SDK
-from pasqal_cloud.utils.constants import BatchStatus, JobStatus, QueuePriority
-from pasqal_cloud.utils.filters import (
-    BatchFilters,
-    CancelJobFilters,
-    JobFilters,
-    PaginationParams,
-    RebatchFilters,
-)
-from pasqal_cloud.utils.responses import (
-    BatchCancellationResponse,
-    JobCancellationResponse,
-    PaginatedResponse,
-)
-from pasqal_cloud.workload import Workload
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
-from pasqal_cloud.ovh import OVHConnection
-from pasqal_cloud.backends import EmuMPSBackend, EmuSVBackend, EmuFreeBackend
+
+def __getattr__(name: str) -> Any:
+    """Lazily re-export deprecated names via ``_deprecations``.
+
+    Any symbol that used to live in ``pasqal_cloud.*`` and was re-exported here
+    is still accessible (``from pasqal_cloud import Batch``, etc.) but will
+    emit a ``DeprecationWarning`` telling users where to import it from.
+
+    These re-exports **will be removed in a future release**.
+    """
+    from pasqal_cloud._deprecations import __getattr__ as _dep_getattr
+
+    return _dep_getattr(name)

--- a/pasqal-cloud/pasqal_cloud/_deprecations.py
+++ b/pasqal-cloud/pasqal_cloud/_deprecations.py
@@ -1,0 +1,99 @@
+"""Backward-compatibility re-exports from pasqal_cloud.
+
+All symbols listed here used to be importable from `pasqal_cloud` directly.
+They are still available for now, but **will be removed from the root
+``pasqal_cloud`` namespace in a future release**.  Please update your imports
+to point to the canonical module instead (shown in the deprecation warning).
+"""
+
+import warnings
+from typing import Any
+
+# Mapping of deprecated names → (canonical module path, object name)
+_DEPRECATED_EXPORTS: dict[str, tuple[str, str]] = {
+    # authentication
+    "TokenProvider": ("pasqal_cloud.authentication", "TokenProvider"),
+    # batch
+    "RESULT_POLLING_INTERVAL": ("pasqal_cloud.batch", "RESULT_POLLING_INTERVAL"),
+    "Batch": ("pasqal_cloud.batch", "Batch"),
+    # http_client (was re-exported as "Client")
+    "Client": ("pasqal_cloud.http_client", "HTTPClient"),
+    # device
+    "BaseConfig": ("pasqal_cloud.device", "BaseConfig"),
+    "DeviceTypeName": ("pasqal_cloud.device", "DeviceTypeName"),
+    "EmulatorType": ("pasqal_cloud.device", "EmulatorType"),
+    # endpoints
+    "AUTH0_CONFIG": ("pasqal_cloud.endpoints", "AUTH0_CONFIG"),
+    "PASQAL_ENDPOINTS": ("pasqal_cloud.endpoints", "PASQAL_ENDPOINTS"),
+    "Auth0Conf": ("pasqal_cloud.endpoints", "Auth0Conf"),
+    "Endpoints": ("pasqal_cloud.endpoints", "Endpoints"),
+    "Region": ("pasqal_cloud.endpoints", "Region"),
+    "TokenProviderConf": ("pasqal_cloud.endpoints", "TokenProviderConf"),
+    # errors
+    "BatchCancellingError": ("pasqal_cloud.errors", "BatchCancellingError"),
+    "BatchClosingError": ("pasqal_cloud.errors", "BatchClosingError"),
+    "BatchCreationError": ("pasqal_cloud.errors", "BatchCreationError"),
+    "BatchFetchingError": ("pasqal_cloud.errors", "BatchFetchingError"),
+    "BatchSetTagsError": ("pasqal_cloud.errors", "BatchSetTagsError"),
+    "DeviceSpecsFetchingError": ("pasqal_cloud.errors", "DeviceSpecsFetchingError"),
+    "InvalidDeviceTypeSet": ("pasqal_cloud.errors", "InvalidDeviceTypeSet"),
+    "JobCancellingError": ("pasqal_cloud.errors", "JobCancellingError"),
+    "JobCreationError": ("pasqal_cloud.errors", "JobCreationError"),
+    "JobFetchingError": ("pasqal_cloud.errors", "JobFetchingError"),
+    "OnlyCompleteOrOpenCanBeSet": (
+        "pasqal_cloud.errors",
+        "OnlyCompleteOrOpenCanBeSet",
+    ),
+    "ProjectFetchingError": ("pasqal_cloud.errors", "ProjectFetchingError"),
+    "ProjectNotFoundError": ("pasqal_cloud.errors", "ProjectNotFoundError"),
+    "RebatchError": ("pasqal_cloud.errors", "RebatchError"),
+    "WorkloadCancellingError": ("pasqal_cloud.errors", "WorkloadCancellingError"),
+    "WorkloadCreationError": ("pasqal_cloud.errors", "WorkloadCreationError"),
+    "WorkloadFetchingError": ("pasqal_cloud.errors", "WorkloadFetchingError"),
+    # job
+    "CreateJob": ("pasqal_cloud.job", "CreateJob"),
+    "Job": ("pasqal_cloud.job", "Job"),
+    # project
+    "Project": ("pasqal_cloud.project", "Project"),
+    # sdk
+    "SDK": ("pasqal_cloud.sdk", "SDK"),
+    # utils.constants
+    "BatchStatus": ("pasqal_cloud.utils.constants", "BatchStatus"),
+    "JobStatus": ("pasqal_cloud.utils.constants", "JobStatus"),
+    "QueuePriority": ("pasqal_cloud.utils.constants", "QueuePriority"),
+    # utils.filters
+    "BatchFilters": ("pasqal_cloud.utils.filters", "BatchFilters"),
+    "CancelJobFilters": ("pasqal_cloud.utils.filters", "CancelJobFilters"),
+    "JobFilters": ("pasqal_cloud.utils.filters", "JobFilters"),
+    "PaginationParams": ("pasqal_cloud.utils.filters", "PaginationParams"),
+    "RebatchFilters": ("pasqal_cloud.utils.filters", "RebatchFilters"),
+    # utils.responses
+    "BatchCancellationResponse": (
+        "pasqal_cloud.utils.responses",
+        "BatchCancellationResponse",
+    ),
+    "JobCancellationResponse": (
+        "pasqal_cloud.utils.responses",
+        "JobCancellationResponse",
+    ),
+    "PaginatedResponse": ("pasqal_cloud.utils.responses", "PaginatedResponse"),
+    # workload
+    "Workload": ("pasqal_cloud.workload", "Workload"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED_EXPORTS:
+        module_path, attr = _DEPRECATED_EXPORTS[name]
+        warnings.warn(
+            f"Importing '{name}' from 'pasqal_cloud' is deprecated and will be "
+            f"removed in a future release. "
+            f"Please use 'from {module_path} import {attr}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, attr)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pasqal-cloud/pasqal_cloud/_deprecations.py
+++ b/pasqal-cloud/pasqal_cloud/_deprecations.py
@@ -16,8 +16,8 @@ _DEPRECATED_EXPORTS: dict[str, tuple[str, str]] = {
     # batch
     "RESULT_POLLING_INTERVAL": ("pasqal_cloud.batch", "RESULT_POLLING_INTERVAL"),
     "Batch": ("pasqal_cloud.batch", "Batch"),
-    # http_client (was re-exported as "Client")
-    "Client": ("pasqal_cloud.http_client", "HTTPClient"),
+    # client
+    "Client": ("pasqal_cloud.client", "Client"),
     # device
     "BaseConfig": ("pasqal_cloud.device", "BaseConfig"),
     "DeviceTypeName": ("pasqal_cloud.device", "DeviceTypeName"),

--- a/pasqal-cloud/pasqal_cloud/_deprecations.py
+++ b/pasqal-cloud/pasqal_cloud/_deprecations.py
@@ -87,7 +87,7 @@ def __getattr__(name: str) -> Any:
         module_path, attr = _DEPRECATED_EXPORTS[name]
         warnings.warn(
             f"Importing '{name}' from 'pasqal_cloud' is deprecated and will be "
-            f"removed in a future release. "
+            "removed in a future release. "
             f"Please use 'from {module_path} import {attr}' instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import warnings
 from typing import Any, ClassVar
 
-import pasqal_cloud
 import pulser
 from pasqal_cloud.device.device_types import DeviceTypeName
 from pulser.backend import BitStrings, EmulationConfig, EmulatorBackend
@@ -133,7 +132,7 @@ class EmuMPSBackend(RemoteEmulatorBackend):
         autosave_dt=float("inf"),
         optimize_qubit_ordering=True,
     )
-    _device_type = pasqal_cloud.DeviceTypeName.EMU_MPS
+    _device_type = DeviceTypeName.EMU_MPS
 
 
 class EmuSVBackend(RemoteEmulatorBackend):
@@ -156,7 +155,7 @@ class EmuSVBackend(RemoteEmulatorBackend):
     default_config = EmulationConfig(
         observables=[BitStrings()],
     )
-    _device_type = pasqal_cloud.DeviceTypeName.EMU_SV
+    _device_type = DeviceTypeName.EMU_SV
 
 
 class EmuFreeBackend(RemoteEmulatorBackend):
@@ -177,4 +176,4 @@ class EmuFreeBackend(RemoteEmulatorBackend):
     """
 
     default_config = EmulationConfig(observables=[BitStrings()])
-    _device_type = pasqal_cloud.DeviceTypeName.EMU_FREE
+    _device_type = DeviceTypeName.EMU_FREE

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -23,7 +23,7 @@ from pasqal_cloud.device.device_types import DeviceTypeName
 from pulser.backend import BitStrings, EmulationConfig, EmulatorBackend
 from pulser.backend.remote import JobParams, RemoteBackend, RemoteResults
 
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 
 class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):
@@ -32,7 +32,7 @@ class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):
     def __init__(
         self,
         sequence: pulser.Sequence,
-        connection: PasqalCloud,
+        connection: PasqalCloudConnection,
         *,
         config: EmulationConfig | None = None,
         mimic_qpu: bool = False,

--- a/pasqal-cloud/pasqal_cloud/batch.py
+++ b/pasqal-cloud/pasqal_cloud/batch.py
@@ -5,7 +5,7 @@ from warnings import warn
 from pydantic import BaseModel, ConfigDict, field_validator, PrivateAttr, ValidationInfo
 from requests import HTTPError
 
-from pasqal_cloud.client import Client
+from pasqal_cloud.http_client import HTTPClient
 from pasqal_cloud.device import DeviceTypeName
 from pasqal_cloud.device.configuration import (
     BaseConfig,
@@ -46,7 +46,7 @@ class Batch(BaseModel):
         user_id: Unique identifier of the user that created the batch.
         status: Status of the batch. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
-        _client: A Client instance to connect to PCS.
+        _client: A HTTPClient instance to connect to PCS.
         ordered_jobs: List of all the jobs added to the batch,
             ordered by creation time.
         jobs_count: Number of jobs added to the batch.
@@ -78,7 +78,7 @@ class Batch(BaseModel):
     id: str
     user_id: str
     status: str
-    _client: Client = PrivateAttr()
+    _client: HTTPClient = PrivateAttr()
     _ordered_jobs: Optional[List[Job]] = PrivateAttr(default=None)
     jobs_count: int = 0
     jobs_count_per_status: Dict[str, int] = {}

--- a/pasqal-cloud/pasqal_cloud/client.py
+++ b/pasqal-cloud/pasqal_cloud/client.py
@@ -1,0 +1,16 @@
+import warnings
+from typing import Any
+
+from pasqal_cloud.http_client import HTTPClient
+
+
+class Client(HTTPClient):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "'Client' is an alias to 'HTTPClient' and will be "
+            "removed in a future release. "
+            "Please use 'HTTPClient' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -54,7 +54,7 @@ def _skip_gzip_request_body() -> bool:
     return bool(os.getenv("PASQAL_SKIP_GZIP_REQUEST_BODY", False))
 
 
-class Client:
+class HTTPClient:
     authenticator: AuthBase | None
 
     def __init__(
@@ -111,8 +111,7 @@ class Client:
             "get_batch": f"{self.endpoints.core}/api/v2/batches/{{batch_id}}",
             "close_batch": f"{self.endpoints.core}/api/v2/"
             f"batches/{{batch_id}}/complete",
-            "cancel_batch": f"{self.endpoints.core}/api/v2/"
-            f"batches/{{batch_id}}/cancel",
+            "cancel_batch": f"{self.endpoints.core}/api/v2/batches/{{batch_id}}/cancel",
             "cancel_batches": f"{self.endpoints.core}/api/v1/batches/cancel",
             "rebatch": f"{self.endpoints.core}/api/v1/batches/{{batch_id}}/rebatch",
             "get_batches": f"{self.endpoints.core}/api/v1/batches",

--- a/pasqal-cloud/pasqal_cloud/job.py
+++ b/pasqal-cloud/pasqal_cloud/job.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, TypedDict, Union
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 from requests import HTTPError
 
-from pasqal_cloud.client import Client
+from pasqal_cloud.http_client import HTTPClient
 from pasqal_cloud.errors import JobCancellingError
 from pasqal_cloud.utils.jsend import JobResult
 
@@ -18,7 +18,7 @@ class Job(BaseModel):
         project_id: ID of the project which the users scheduling the job belong to.
         status: Status of the job. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
-        _client: A Client instance to connect to PCS.
+        _client: A HTTPClient instance to connect to PCS.
         created_at: Timestamp of the creation of the job.
         updated_at: Timestamp of the last update of the job.
         errors: Error messages that occurred while processing job.
@@ -40,7 +40,7 @@ class Job(BaseModel):
     id: str
     project_id: str
     status: str
-    _client: Client = PrivateAttr()
+    _client: HTTPClient = PrivateAttr()
     created_at: str
     updated_at: str
     errors: Optional[List[str]] = None

--- a/pasqal-cloud/pasqal_cloud/ovh.py
+++ b/pasqal-cloud/pasqal_cloud/ovh.py
@@ -7,7 +7,7 @@ from pasqal_cloud.authentication import TokenProvider
 from pasqal_cloud.http_client import HTTPClient
 
 from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 
 class OvhClient(HTTPClient):
@@ -58,7 +58,7 @@ class MissingEnvironmentVariableError(RuntimeError):
     pass
 
 
-class OVHConnection(PasqalCloud):
+class OVHConnection(PasqalCloudConnection):
     """PasqalCloud connection designed for OVH users.
 
     This connection class enables OVH users to access Pasqal Cloud services.

--- a/pasqal-cloud/pasqal_cloud/ovh.py
+++ b/pasqal-cloud/pasqal_cloud/ovh.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import os
 from typing import Any, Dict
 
-import pasqal_cloud
 from pasqal_cloud.authentication import TokenProvider
-from pasqal_cloud.client import Client
+from pasqal_cloud.http_client import HTTPClient
 
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
 
 
-class OvhClient(Client):
+class OvhClient(HTTPClient):
     """OVH specific client that uses different API endpoints."""
 
     @property
@@ -82,7 +82,7 @@ class OVHConnection(PasqalCloud):
             def get_token(self) -> str:
                 return token
 
-        self._sdk_connection = pasqal_cloud.SDK(
+        self._sdk_connection = PasqalCloudClient(
             token_provider=OvhTokenProvider(), client_class=OvhClient, **kwargs
         )
 

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_client.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_client.py
@@ -8,7 +8,7 @@ from requests.exceptions import HTTPError
 
 from pasqal_cloud.authentication import TokenProvider
 from pasqal_cloud.batch import RESULT_POLLING_INTERVAL, Batch
-from pasqal_cloud.client import Client
+from pasqal_cloud.http_client import HTTPClient
 from pasqal_cloud.device import BaseConfig, DeviceTypeName, EmulatorType
 from pasqal_cloud.endpoints import Auth0Conf, Endpoints, Region, TokenProviderConf
 from pasqal_cloud.errors import (
@@ -83,8 +83,8 @@ def _check_sdk_version() -> None:
         )
 
 
-class SDK:
-    _client: Client
+class PasqalCloudClient:
+    _client: HTTPClient
 
     def __init__(
         self,
@@ -95,7 +95,7 @@ class SDK:
         auth0: Optional[Auth0Conf] = None,
         webhook: Optional[str] = None,
         project_id: Optional[str] = None,
-        client_class: Type[Client] = Client,
+        client_class: Type[HTTPClient] = HTTPClient,
         region: Optional[Region] = None,
         auth_config: Optional[TokenProviderConf] = None,
     ):

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
@@ -48,7 +48,7 @@ retry = tenacity.retry(
 )
 
 
-class PasqalCloud(RemoteConnection):
+class PasqalCloudConnection(RemoteConnection):
     """Manager of the connection to PASQAL's cloud platform.
 
     The cloud connection enables to run sequences on simulators or on real

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, cast
 
-import pasqal_cloud
+from pasqal_cloud.device.device_types import DeviceTypeName
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 import tenacity
 from pasqal_cloud.endpoints import Region
 from pasqal_cloud.job import CreateJob
@@ -57,7 +58,7 @@ class PasqalCloud(RemoteConnection):
         username: Your username in the PASQAL cloud platform.
         password: The password for your PASQAL cloud platform account.
         project_id: The project ID associated to the account.
-        kwargs: Additional arguments to provide to the pasqal_cloud.SDK()
+        kwargs: Additional arguments to provide to the PasqalCloudClient()
     """
 
     def __init__(
@@ -69,7 +70,7 @@ class PasqalCloud(RemoteConnection):
         **kwargs: Any,
     ):
         """Initializes a connection to the Pasqal cloud platform."""
-        self._sdk_connection = pasqal_cloud.SDK(
+        self._sdk_connection = PasqalCloudClient(
             username=username,
             password=password,
             project_id=project_id,
@@ -83,7 +84,7 @@ class PasqalCloud(RemoteConnection):
         wait: bool = False,
         open: bool = False,
         batch_id: str | None = None,
-        device_type: pasqal_cloud.DeviceTypeName | None = None,
+        device_type: DeviceTypeName | None = None,
         backend_configuration: EmulationConfig | None = None,
         **kwargs: Any,
     ) -> RemoteResults:

--- a/pasqal-cloud/pasqal_cloud/sdk.py
+++ b/pasqal-cloud/pasqal_cloud/sdk.py
@@ -1,0 +1,16 @@
+import warnings
+from typing import Any
+
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
+
+
+class SDK(PasqalCloudClient):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "'SDK' is an alias to 'PasqalCloudClient' and will be "
+            "removed in a future release. "
+            "Please use 'PasqalCloudClient' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/pasqal-cloud/pasqal_cloud/workload.py
+++ b/pasqal-cloud/pasqal_cloud/workload.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, field_validator, PrivateAttr
 from pydantic_core.core_schema import ValidationInfo
 from requests import HTTPError
 
-from pasqal_cloud.client import _skip_ssl_verify, Client
+from pasqal_cloud.http_client import _skip_ssl_verify, HTTPClient
 from pasqal_cloud.errors import (
     InvalidWorkloadResultsFormatError,
     WorkloadCancellingError,
@@ -26,7 +26,7 @@ class Workload(BaseModel):
             belong to.
         status: Status of the workload. Possible values are:
             PENDING, RUNNING, DONE, CANCELED, TIMED_OUT, ERROR, PAUSED.
-        _client: A Client instance to connect to PCS.
+        _client: A HTTPClient instance to connect to PCS.
         backend: The backend used for the workload.
         workload_type: The type of the workload.
         config: The config containing all the necessary information for
@@ -42,7 +42,7 @@ class Workload(BaseModel):
     id: str
     project_id: str
     status: str
-    _client: Client = PrivateAttr()
+    _client: HTTPClient = PrivateAttr()
     backend: str
     workload_type: str
     config: Dict[str, Any]

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -15,7 +15,7 @@ from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
 
 @patch(
-    "pasqal_cloud.client.PasswordGrantTokenProvider",
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
     FakeAuth0AuthenticationSuccess,
 )
 @pytest.mark.parametrize("job_params", [None, [JobParams(runs=10)]])
@@ -54,7 +54,10 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
 
 
-@patch("pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess)
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
 def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.Mocker):
     mock_request.reset_mock()
     connection = PasqalCloud(username="test", password="test", project_id=str(uuid4()))

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -9,7 +9,7 @@ from pulser.backend import BitStrings, CorrelationMatrix
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
 from pasqal_cloud.backends import EmuFreeBackend
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
@@ -21,7 +21,9 @@ from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 @pytest.mark.parametrize("job_params", [None, [JobParams(runs=10)]])
 def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params):
     mock_request.reset_mock()
-    connection = PasqalCloud(username="test", password="test", project_id=str(uuid4()))
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
 
     device = AnalogDevice
     register = Register.from_coordinates([(0, 0)], prefix="q")
@@ -60,7 +62,9 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
 )
 def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.Mocker):
     mock_request.reset_mock()
-    connection = PasqalCloud(username="test", password="test", project_id=str(uuid4()))
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
 
     device = AnalogDevice
     register = Register.from_coordinates([(0, 0)], prefix="q")

--- a/tests/backend/test_emu_mps.py
+++ b/tests/backend/test_emu_mps.py
@@ -29,7 +29,7 @@ test_device = dataclasses.replace(
 )
 @pytest.mark.parametrize("job_params", [None, [JobParams(runs=10)]])
 @patch(
-    "pasqal_cloud.client.PasswordGrantTokenProvider",
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
     FakeAuth0AuthenticationSuccess,
 )
 def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, config):

--- a/tests/backend/test_emu_mps.py
+++ b/tests/backend/test_emu_mps.py
@@ -10,7 +10,7 @@ from pulser import AnalogDevice, DigitalAnalogDevice, Register, Sequence
 from pulser.backend import BitStrings, EmulationConfig
 from pulser.backend.remote import JobParams
 from pasqal_cloud.backends import EmuMPSBackend
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
@@ -34,7 +34,9 @@ test_device = dataclasses.replace(
 )
 def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, config):
     mock_request.reset_mock()
-    connection = PasqalCloud(username="test", password="test", project_id=str(uuid4()))
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
 
     device = AnalogDevice
     register = Register.from_coordinates([(0, 0)], prefix="q")

--- a/tests/backend/test_emu_sv.py
+++ b/tests/backend/test_emu_sv.py
@@ -22,7 +22,7 @@ test_device = dataclasses.replace(
 
 
 @patch(
-    "pasqal_cloud.client.PasswordGrantTokenProvider",
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
     FakeAuth0AuthenticationSuccess,
 )
 def test_emu_sv_backend(mock_request: requests_mock.mocker.Mocker):

--- a/tests/backend/test_emu_sv.py
+++ b/tests/backend/test_emu_sv.py
@@ -7,7 +7,7 @@ from pulser import AnalogDevice, DigitalAnalogDevice, Register, Sequence
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
 from pasqal_cloud.backends import EmuSVBackend
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloud
+from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
@@ -27,7 +27,9 @@ test_device = dataclasses.replace(
 )
 def test_emu_sv_backend(mock_request: requests_mock.mocker.Mocker):
     mock_request.reset_mock()
-    connection = PasqalCloud(username="test", password="test", project_id=str(uuid4()))
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
 
     device = AnalogDevice
     register = Register.from_coordinates([(0, 0)], prefix="q")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 
 import pytest
 import requests_mock
-from pasqal_cloud import Batch, Client, Job, Workload
+from pasqal_cloud import Batch, Job, Workload
+from pasqal_cloud.http_client import HTTPClient
 from pasqal_cloud.endpoints import Endpoints
 from requests import HTTPError, Request
 
@@ -157,11 +158,11 @@ def mock_request_exception(request_mock_exception) -> Generator[Any, Any, None]:
 
 @pytest.fixture
 @patch(
-    "pasqal_cloud.client.PasswordGrantTokenProvider",
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
     FakeAuth0AuthenticationSuccess,
 )
 def pasqal_client_mock():
-    return Client(
+    return HTTPClient(
         project_id="00000000-0000-0000-0000-000000000002",
         username="00000000-0000-0000-0000-000000000001",
         password="password",

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -15,8 +15,8 @@ from pasqal_cloud import (
     PaginatedResponse,
     PaginationParams,
     RebatchFilters,
-    SDK,
 )
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 from pasqal_cloud.batch import Batch as BatchModel
 from pasqal_cloud.device import (
     BaseConfig,
@@ -63,11 +63,11 @@ class TestBatch:
 
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider",
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
         FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from pasqal_cloud import SDK
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
@@ -11,17 +11,17 @@ from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 class TestDeprecation:
     # set deprecation to 10 day after today (in warning window)
     @patch(
-        "pasqal_cloud.sdk.deprecation_date",
+        "pasqal_cloud.pasqal_cloud_client.deprecation_date",
         (datetime.now() + timedelta(days=10)).strftime("%Y-%m-%d"),
     )
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider",
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
         FakeAuth0AuthenticationSuccess,
     )
     def test_soon_to_be_deprecated(self):
         # Set deprecation_date to be 10 days from now (within the warning period)
         with pytest.warns(DeprecationWarning, match="will be deprecated on "):
-            _ = SDK(
+            _ = PasqalCloudClient(
                 username="me@test.com",
                 password="password",
                 project_id=str(uuid4()),
@@ -29,16 +29,16 @@ class TestDeprecation:
 
     # set deprecation to 1 day before today
     @patch(
-        "pasqal_cloud.sdk.deprecation_date",
+        "pasqal_cloud.pasqal_cloud_client.deprecation_date",
         (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d"),
     )
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider",
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
         FakeAuth0AuthenticationSuccess,
     )
     def test_already_deprecated(self):
         with pytest.warns(DeprecationWarning, match="is no longer supported."):
-            _ = SDK(
+            _ = PasqalCloudClient(
                 username="me@test.com",
                 password="password",
                 project_id=str(uuid4()),

--- a/tests/test_device_specs.py
+++ b/tests/test_device_specs.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pytest
 import requests_mock
-from pasqal_cloud import SDK
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 from pasqal_cloud.errors import DeviceSpecsFetchingError
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -14,10 +14,11 @@ from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 class TestDeviceSpecs:
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com", password="password", project_id=str(uuid4())
         )
 
@@ -56,7 +57,7 @@ class TestDeviceSpecs:
         private endpoint.
         """
 
-        sdk_without_auth = SDK()
+        sdk_without_auth = PasqalCloudClient()
         public_device_specs_dict = sdk_without_auth.get_device_specs_dict()
 
         assert (

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -11,11 +11,11 @@ from auth0.v3.exceptions import Auth0Error
 from pasqal_cloud import (
     AUTH0_CONFIG,
     Auth0Conf,
-    Client,
     Endpoints,
     PASQAL_ENDPOINTS,
-    SDK,
 )
+from pasqal_cloud.http_client import HTTPClient
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 from pasqal_cloud._version import __version__ as sdk_version
 from pasqal_cloud.authentication import TokenProvider
 from pasqal_cloud.endpoints import TokenProviderConf
@@ -36,25 +36,30 @@ class TestSDKCommonAttributes:
     no_password = ""
 
 
-@patch("pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess)
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
 class TestAuthSuccess(TestSDKCommonAttributes):
-    @patch("pasqal_cloud.client.getpass")
+    @patch("pasqal_cloud.http_client.getpass")
     def test_module_getpass_success(self, getpass):
         getpass.return_value = self.password
-        SDK(project_id=self.project_id, username=self.username)
+        PasqalCloudClient(project_id=self.project_id, username=self.username)
         getpass.assert_called_once()
 
     def test_authentication_success(self):
-        SDK(project_id=self.project_id, username=self.username, password=self.password)
+        PasqalCloudClient(
+            project_id=self.project_id, username=self.username, password=self.password
+        )
 
     def test_good_token_provider(self):
-        SDK(
+        PasqalCloudClient(
             project_id=self.project_id,
             token_provider=FakeAuth0AuthenticationSuccess("username", "password", None),
         )
 
     def test_get_token_good_token_provider(self):
-        sdk = SDK(
+        sdk = PasqalCloudClient(
             project_id=self.project_id,
             token_provider=FakeAuth0AuthenticationSuccess("username", "password", None),
         )
@@ -67,7 +72,7 @@ class TestAuthSuccess(TestSDKCommonAttributes):
             def get_token(self):
                 return "your-token"  # Replace this value with your token
 
-        SDK(token_provider=CustomTokenProvider(), project_id="project_id")
+        PasqalCloudClient(token_provider=CustomTokenProvider(), project_id="project_id")
 
     def test_get_token_custom_token_provider(self):
         """Test that the custom provider suggested in the readme is working"""
@@ -78,7 +83,9 @@ class TestAuthSuccess(TestSDKCommonAttributes):
             def get_token(self):
                 return CUSTOM_TOKEN
 
-        sdk = SDK(token_provider=CustomTokenProvider(), project_id="project_id")
+        sdk = PasqalCloudClient(
+            token_provider=CustomTokenProvider(), project_id="project_id"
+        )
         assert sdk.user_token() == CUSTOM_TOKEN
 
     @pytest.mark.filterwarnings(
@@ -86,7 +93,7 @@ class TestAuthSuccess(TestSDKCommonAttributes):
         " 'env' instead"
     )
     def test_correct_endpoints(self):
-        sdk = SDK(
+        sdk = PasqalCloudClient(
             project_id=self.project_id,
             username=self.username,
             password=self.password,
@@ -100,7 +107,7 @@ class TestAuthSuccess(TestSDKCommonAttributes):
     )
     def test_correct_new_auth0(self):
         new_auth0 = Auth0Conf(domain="new_domain")
-        SDK(
+        PasqalCloudClient(
             project_id=self.project_id,
             username=self.username,
             password=self.password,
@@ -108,7 +115,7 @@ class TestAuthSuccess(TestSDKCommonAttributes):
         )
 
     def test_module_no_project_id(self):
-        sdk = SDK(username=self.username, password=self.password)
+        sdk = PasqalCloudClient(username=self.username, password=self.password)
         with pytest.raises(
             ValueError,
             match="You need to set a project_id",
@@ -116,20 +123,23 @@ class TestAuthSuccess(TestSDKCommonAttributes):
             sdk.create_batch("", [])
 
 
-@patch("pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationFailure)
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationFailure,
+)
 class TestAuthFailure(TestSDKCommonAttributes):
-    @patch("pasqal_cloud.client.getpass")
+    @patch("pasqal_cloud.http_client.getpass")
     def test_module_getpass_bad_password(self, getpass):
         getpass.return_value = self.password
 
         with pytest.raises(Auth0Error):
-            SDK(project_id=self.project_id, username=self.username)
+            PasqalCloudClient(project_id=self.project_id, username=self.username)
 
         getpass.assert_called_once()
 
     def test_module_bad_password(self):
         with pytest.raises(Auth0Error):
-            SDK(
+            PasqalCloudClient(
                 project_id=self.project_id,
                 username=self.username,
                 password=self.password,
@@ -154,7 +164,7 @@ class TestInvalidAuthConfig(TestSDKCommonAttributes):
             ValueError,
             match="The auth0 and auth_config parameters cannot be used simultaneously.",
         ):
-            _ = SDK(
+            _ = PasqalCloudClient(
                 project_id=self.project_id,
                 username=self.username,
                 password=self.password,
@@ -163,10 +173,13 @@ class TestInvalidAuthConfig(TestSDKCommonAttributes):
             )
 
 
-@patch("pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationFailure)
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationFailure,
+)
 class TestAuthInvalidClient(TestSDKCommonAttributes):
     def test_module_no_user_with_password(self):
-        sdk = SDK(
+        sdk = PasqalCloudClient(
             project_id=self.project_id,
             username=self.no_username,
             password=self.password,
@@ -178,36 +191,36 @@ class TestAuthInvalidClient(TestSDKCommonAttributes):
         ):
             sdk.get_batch("fake-id")
 
-    @patch("pasqal_cloud.client.getpass")
+    @patch("pasqal_cloud.http_client.getpass")
     def test_module_no_password(self, getpass):
         getpass.return_value = ""
         with pytest.raises(
             ValueError, match="The prompted password should not be empty"
         ):
-            SDK(
+            PasqalCloudClient(
                 project_id=self.project_id,
                 username=self.username,
                 password=self.no_password,
             )
 
-    @patch("pasqal_cloud.client.getpass")
+    @patch("pasqal_cloud.http_client.getpass")
     def test_module_getpass_no_password(self, getpass):
         getpass.return_value = self.no_password
 
         with pytest.raises(
             ValueError, match="The prompted password should not be empty"
         ):
-            SDK(project_id=self.project_id, username=self.username)
+            PasqalCloudClient(project_id=self.project_id, username=self.username)
 
         getpass.assert_called_once()
 
     def test_bad_token_provider(self):
         with pytest.raises(TypeError):
-            SDK(project_id=self.project_id, token_provider="token")
+            PasqalCloudClient(project_id=self.project_id, token_provider="token")
 
     def test_bad_auth0(self):
         with pytest.raises(TypeError):
-            SDK(
+            PasqalCloudClient(
                 project_id=self.project_id,
                 username=self.username,
                 password=self.password,
@@ -215,7 +228,7 @@ class TestAuthInvalidClient(TestSDKCommonAttributes):
             )
 
     def test_authentication_no_credentials_provided(self):
-        sdk = SDK(project_id=self.project_id)
+        sdk = PasqalCloudClient(project_id=self.project_id)
         with pytest.raises(
             ValueError,
             match="Authentication required. Please provide your credentials when "
@@ -229,7 +242,7 @@ class TestAuthInvalidClient(TestSDKCommonAttributes):
     )
     def test_bad_endpoints(self):
         with pytest.raises(TypeError):
-            SDK(
+            PasqalCloudClient(
                 project_id=self.project_id,
                 username=self.username,
                 password=self.password,
@@ -240,7 +253,10 @@ class TestAuthInvalidClient(TestSDKCommonAttributes):
             )
 
 
-@patch("pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess)
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
 class TestEnvSDK(TestSDKCommonAttributes):
     @pytest.mark.parametrize(
         ("env", "core_endpoint_expected"),
@@ -251,7 +267,7 @@ class TestEnvSDK(TestSDKCommonAttributes):
         ],
     )
     def test_select_env(self, env: str, core_endpoint_expected: str):
-        sdk = SDK(
+        sdk = PasqalCloudClient(
             project_id=self.project_id,
             username=self.username,
             password=self.password,
@@ -270,10 +286,11 @@ class TestSDKRetry:
 
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),
@@ -349,7 +366,8 @@ class TestSDKRetry:
 
     # re-enable gzip compression
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def test_sdk_gzip_requests(
         self, mock_request: requests_mock.mocker.Mocker, monkeypatch: pytest.MonkeyPatch
@@ -360,7 +378,7 @@ class TestSDKRetry:
         """
         monkeypatch.setenv("PASQAL_SKIP_GZIP_REQUEST_BODY", "")
         # Reinitialize SDK with the env var set
-        sdk = SDK(
+        sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),
@@ -440,10 +458,11 @@ class TestSDKRetry:
 class TestRequestAllPages:
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),
@@ -572,10 +591,11 @@ class TestRequestAllPages:
 class TestHeaders:
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),
@@ -600,7 +620,7 @@ class TestHeaders:
         )
 
     def test_client_endpoint_does_not_exist(self):
-        client = Client()
+        client = HTTPClient()
         # 'add_job' does not exist in Client urls
         with pytest.raises(
             ValueError,

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -15,8 +15,8 @@ from pasqal_cloud import (
     JobFilters,
     PaginatedResponse,
     PaginationParams,
-    SDK,
 )
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 from pasqal_cloud.utils.constants import JobStatus
 from pasqal_cloud.utils.responses import JobCancellationResponse
 
@@ -36,10 +36,11 @@ class TestJob:
 
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -2,7 +2,8 @@ from unittest.mock import patch
 
 import pytest
 import requests_mock
-from pasqal_cloud import ProjectNotFoundError, SDK
+from pasqal_cloud import ProjectNotFoundError
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
@@ -10,11 +11,12 @@ from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 class TestProject:
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
         self.project_id = "73feca86-a140-4ed8-a8e7-fe71428e0542"
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com", password="password", project_id=self.project_id
         )
 

--- a/tests/test_remote_connections.py
+++ b/tests/test_remote_connections.py
@@ -47,13 +47,13 @@ root = Path(__file__).parent.parent
 @dataclasses.dataclass
 class OVHFixture:
     ovh_connection: OVHConnection
-    mock_cloud_sdk: Any
+    mock_cloud_client: Any
 
 
 @dataclasses.dataclass
 class CloudFixture:
     pasqal_cloud: PasqalCloud
-    mock_cloud_sdk: Any
+    mock_cloud_client: Any
 
 
 test_device = dataclasses.replace(
@@ -139,23 +139,27 @@ def mock_batch():
 
 def mock_pasqal_cloud_ovh_sdk(mock_batch):
     os.environ["PASQAL_PULSER_ACCESS_TOKEN"] = "fake-ovh-token"
-    with patch("pasqal_cloud.SDK", autospec=True) as mock_cloud_sdk_class:
+    with patch(
+        "pasqal_cloud.pasqal_cloud_client.PasqalCloudClient", autospec=True
+    ) as mock_cloud_client:
         ovh = OVHConnection()
-        mock_cloud_sdk = mock_cloud_sdk_class.return_value
-        mock_cloud_sdk_class.reset_mock()
-        mock_cloud_sdk.create_batch = MagicMock(return_value=mock_batch)
-        mock_cloud_sdk.get_batch = MagicMock(return_value=mock_batch)
-        mock_cloud_sdk.add_jobs = MagicMock(return_value=mock_batch)
-        mock_cloud_sdk._close_batch = MagicMock(return_value=None)
-        mock_cloud_sdk.get_device_specs_dict = MagicMock(
+        mock_cloud_client = mock_cloud_client.return_value
+        mock_cloud_client.reset_mock()
+        mock_cloud_client.create_batch = MagicMock(return_value=mock_batch)
+        mock_cloud_client.get_batch = MagicMock(return_value=mock_batch)
+        mock_cloud_client.add_jobs = MagicMock(return_value=mock_batch)
+        mock_cloud_client._close_batch = MagicMock(return_value=None)
+        mock_cloud_client.get_device_specs_dict = MagicMock(
             return_value={test_device.name: test_device.to_abstract_repr()}
         )
 
-        return OVHFixture(ovh_connection=ovh, mock_cloud_sdk=mock_cloud_sdk)
+        return OVHFixture(ovh_connection=ovh, mock_cloud_client=mock_cloud_client)
 
 
 def mock_pasqal_cloud_sdk(mock_batch):
-    with patch("pasqal_cloud.SDK", autospec=True) as mock_cloud_sdk_class:
+    with patch(
+        "pasqal_cloud.pasqal_cloud_client.PasqalCloudClient", autospec=True
+    ) as mock_cloud_client:
         pasqal_cloud_kwargs = {
             "username": "abc",
             "password": "def",
@@ -167,21 +171,23 @@ def mock_pasqal_cloud_sdk(mock_batch):
 
         pasqal_cloud = PasqalCloud(**pasqal_cloud_kwargs)
 
-        mock_cloud_sdk_class.assert_called_once_with(**pasqal_cloud_kwargs)
+        mock_cloud_client.assert_called_once_with(**pasqal_cloud_kwargs)
 
-        mock_cloud_sdk = mock_cloud_sdk_class.return_value
+        mock_cloud_client = mock_cloud_client.return_value
 
-        mock_cloud_sdk_class.reset_mock()
+        mock_cloud_client.reset_mock()
 
-        mock_cloud_sdk.create_batch = MagicMock(return_value=mock_batch)
-        mock_cloud_sdk.get_batch = MagicMock(return_value=mock_batch)
-        mock_cloud_sdk.add_jobs = MagicMock(return_value=mock_batch)
-        mock_cloud_sdk._close_batch = MagicMock(return_value=None)
-        mock_cloud_sdk.get_device_specs_dict = MagicMock(
+        mock_cloud_client.create_batch = MagicMock(return_value=mock_batch)
+        mock_cloud_client.get_batch = MagicMock(return_value=mock_batch)
+        mock_cloud_client.add_jobs = MagicMock(return_value=mock_batch)
+        mock_cloud_client._close_batch = MagicMock(return_value=None)
+        mock_cloud_client.get_device_specs_dict = MagicMock(
             return_value={test_device.name: test_device.to_abstract_repr()}
         )
 
-        return CloudFixture(pasqal_cloud=pasqal_cloud, mock_cloud_sdk=mock_cloud_sdk)
+        return CloudFixture(
+            pasqal_cloud=pasqal_cloud, mock_cloud_client=mock_cloud_client
+        )
 
 
 @pytest.fixture
@@ -202,7 +208,7 @@ def test_remote_results(fixt_pasqal_cloud, mock_batch, with_job_id):
         RemoteResults(
             mock_batch.id, fixt_pasqal_cloud.pasqal_cloud, job_ids=["badjobid"]
         )
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.reset_mock()
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.reset_mock()
 
     select_jobs = (
         mock_batch.ordered_jobs[::-1][:2] if with_job_id else mock_batch.ordered_jobs
@@ -217,28 +223,28 @@ def test_remote_results(fixt_pasqal_cloud, mock_batch, with_job_id):
 
     assert remote_results.batch_id == mock_batch.id
     assert remote_results.job_ids == select_job_ids
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.assert_called_once_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_once_with(
         id=remote_results.batch_id
     )
 
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.reset_mock()
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.reset_mock()
 
     assert remote_results.get_batch_status() == BatchStatus.DONE
 
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.assert_called_once_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_once_with(
         id=remote_results.batch_id
     )
 
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.reset_mock()
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.reset_mock()
     results = remote_results.results
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.assert_called_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_with(
         id=remote_results.batch_id
     )
     assert results == tuple(
         get_pulser_result_from_job_result(job.full_result) for job in select_jobs
     )
 
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.reset_mock()
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.reset_mock()
     available_results = remote_results.get_available_results()
     assert available_results == {
         job.id: get_pulser_result_from_job_result(job.full_result)
@@ -262,7 +268,7 @@ def test_partial_results():
         fixt.pasqal_cloud,
     )
 
-    fixt.mock_cloud_sdk.get_batch.reset_mock()
+    fixt.mock_cloud_client.get_batch.reset_mock()
     with pytest.raises(
         RemoteResultsError,
         match=(
@@ -271,8 +277,8 @@ def test_partial_results():
         ),
     ):
         remote_results.results
-    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(id=remote_results.batch_id)
-    fixt.mock_cloud_sdk.get_batch.reset_mock()
+    fixt.mock_cloud_client.get_batch.assert_called_once_with(id=remote_results.batch_id)
+    fixt.mock_cloud_client.get_batch.reset_mock()
 
     available_results = remote_results.get_available_results()
     assert available_results == {
@@ -284,8 +290,8 @@ def test_partial_results():
         for job in batch.ordered_jobs
         if job.result is not None
     }
-    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(id=remote_results.batch_id)
-    fixt.mock_cloud_sdk.get_batch.reset_mock()
+    fixt.mock_cloud_client.get_batch.assert_called_once_with(id=remote_results.batch_id)
+    fixt.mock_cloud_client.get_batch.reset_mock()
 
     batch = MockBatch(
         status="DONE",
@@ -309,8 +315,8 @@ def test_partial_results():
         ),
     ):
         remote_results.results
-    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(id=remote_results.batch_id)
-    fixt.mock_cloud_sdk.get_batch.reset_mock()
+    fixt.mock_cloud_client.get_batch.assert_called_once_with(id=remote_results.batch_id)
+    fixt.mock_cloud_client.get_batch.reset_mock()
 
     available_results = remote_results.get_available_results()
     assert available_results == {
@@ -322,8 +328,8 @@ def test_partial_results():
         for job in batch.ordered_jobs
         if job.result is not None
     }
-    fixt.mock_cloud_sdk.get_batch.assert_called_once_with(id=remote_results.batch_id)
-    fixt.mock_cloud_sdk.get_batch.reset_mock()
+    fixt.mock_cloud_client.get_batch.assert_called_once_with(id=remote_results.batch_id)
+    fixt.mock_cloud_client.get_batch.reset_mock()
 
 
 @pytest.mark.parametrize("mimic_qpu", [False, True])
@@ -369,8 +375,8 @@ def test_submit(fixt_pasqal_cloud, parametrized, mimic_qpu, seq, mock_batch):
         _job.id: get_pulser_result_from_job_result(_job.full_result)
         for _job in mock_batch.ordered_jobs
     }
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.assert_any_call(id="open_batch")
-    fixt_pasqal_cloud.mock_cloud_sdk.add_jobs.assert_called_once_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_any_call(id="open_batch")
+    fixt_pasqal_cloud.mock_cloud_client.add_jobs.assert_called_once_with(
         "open_batch",
         jobs=job_params,
     )
@@ -380,7 +386,9 @@ def test_submit(fixt_pasqal_cloud, parametrized, mimic_qpu, seq, mock_batch):
 
     assert fixt_pasqal_cloud.pasqal_cloud.supports_open_batch() is True
     fixt_pasqal_cloud.pasqal_cloud._close_batch("open_batch")
-    fixt_pasqal_cloud.mock_cloud_sdk.close_batch.assert_called_once_with("open_batch")
+    fixt_pasqal_cloud.mock_cloud_client.close_batch.assert_called_once_with(
+        "open_batch"
+    )
 
     remote_results = fixt_pasqal_cloud.pasqal_cloud.submit(
         seq,
@@ -397,7 +405,7 @@ def test_submit(fixt_pasqal_cloud, parametrized, mimic_qpu, seq, mock_batch):
     assert not seq.is_measured()
     seq.measure(basis="ground-rydberg")
 
-    fixt_pasqal_cloud.mock_cloud_sdk.create_batch.assert_called_once_with(
+    fixt_pasqal_cloud.mock_cloud_client.create_batch.assert_called_once_with(
         serialized_sequence=seq.to_abstract_repr(),
         jobs=job_params,
         device_type=None,
@@ -418,13 +426,13 @@ def test_submit(fixt_pasqal_cloud, parametrized, mimic_qpu, seq, mock_batch):
     assert isinstance(remote_results, RemoteResults)
     assert remote_results.get_batch_status() == BatchStatus.DONE
 
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.assert_called_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_with(
         id=remote_results.batch_id
     )
 
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.reset_mock()
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.reset_mock()
     results = remote_results.results
-    fixt_pasqal_cloud.mock_cloud_sdk.get_batch.assert_called_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_with(
         id=remote_results.batch_id
     )
     assert results == tuple(
@@ -440,10 +448,12 @@ def test_init_reads_token_and_use_ovh_client(_clear_ovh_test_env):
     by "OvhClient".
     """
     os.environ["PASQAL_PULSER_ACCESS_TOKEN"] = "fake-ovh-token"
-    with patch("pasqal_cloud.SDK") as mock_sdk_class:
+    with patch(
+        "pasqal_cloud.pasqal_cloud_client.PasqalCloudClient"
+    ) as mock_cloud_client:
         ovh.OVHConnection()
-        mock_sdk_class.assert_called_once()
-        called_kwargs = mock_sdk_class.call_args.kwargs
+        mock_cloud_client.assert_called_once()
+        called_kwargs = mock_cloud_client.call_args.kwargs
 
         # Verify token_provider returns the correct token
         token_provider = called_kwargs["token_provider"]
@@ -479,7 +489,7 @@ def test_create_ovh_batch(fixt_ovh_connection, _clear_ovh_test_env):
     the expected arguments
     """
     # Replace pasqal-cloud create_batch method with mock
-    fixt_ovh_connection.mock_cloud_sdk.create_batch = MagicMock()
+    fixt_ovh_connection.mock_cloud_client.create_batch = MagicMock()
 
     # Create a dummy sequence
     reg = SquareLatticeLayout(2, 2, 4).make_mappable_register(2)
@@ -498,7 +508,7 @@ def test_create_ovh_batch(fixt_ovh_connection, _clear_ovh_test_env):
         device_type=DeviceTypeName.FRESNEL,
     )
 
-    fixt_ovh_connection.mock_cloud_sdk.create_batch.assert_called_once_with(
+    fixt_ovh_connection.mock_cloud_client.create_batch.assert_called_once_with(
         serialized_sequence=seq.to_abstract_repr(),
         jobs=job_params,
         device_type=DeviceTypeName.FRESNEL,

--- a/tests/test_remote_connections.py
+++ b/tests/test_remote_connections.py
@@ -140,7 +140,7 @@ def mock_batch():
 def mock_pasqal_cloud_ovh_sdk(mock_batch):
     os.environ["PASQAL_PULSER_ACCESS_TOKEN"] = "fake-ovh-token"
     with patch(
-        "pasqal_cloud.pasqal_cloud_client.PasqalCloudClient", autospec=True
+        "pasqal_cloud.ovh.PasqalCloudClient", autospec=True
     ) as mock_cloud_client:
         ovh = OVHConnection()
         mock_cloud_client = mock_cloud_client.return_value
@@ -158,7 +158,7 @@ def mock_pasqal_cloud_ovh_sdk(mock_batch):
 
 def mock_pasqal_cloud_sdk(mock_batch):
     with patch(
-        "pasqal_cloud.pasqal_cloud_client.PasqalCloudClient", autospec=True
+        "pasqal_cloud.pasqal_cloud_connection.PasqalCloudClient", autospec=True
     ) as mock_cloud_client:
         pasqal_cloud_kwargs = {
             "username": "abc",
@@ -448,9 +448,7 @@ def test_init_reads_token_and_use_ovh_client(_clear_ovh_test_env):
     by "OvhClient".
     """
     os.environ["PASQAL_PULSER_ACCESS_TOKEN"] = "fake-ovh-token"
-    with patch(
-        "pasqal_cloud.pasqal_cloud_client.PasqalCloudClient"
-    ) as mock_cloud_client:
+    with patch("pasqal_cloud.ovh.PasqalCloudClient") as mock_cloud_client:
         ovh.OVHConnection()
         mock_cloud_client.assert_called_once()
         called_kwargs = mock_cloud_client.call_args.kwargs

--- a/tests/test_remote_connections.py
+++ b/tests/test_remote_connections.py
@@ -38,7 +38,7 @@ from pulser.devices import DigitalAnalogDevice
 from pulser.register.special_layouts import SquareLatticeLayout
 from pulser.result import SampledResult
 from pulser.sequence import Sequence
-from pasqal_cloud import Endpoints, ovh, OVHConnection, PasqalCloud
+from pasqal_cloud import Endpoints, ovh, OVHConnection, PasqalCloudConnection
 from pasqal_cloud.ovh import MissingEnvironmentVariableError, OvhClient
 
 root = Path(__file__).parent.parent
@@ -52,7 +52,7 @@ class OVHFixture:
 
 @dataclasses.dataclass
 class CloudFixture:
-    pasqal_cloud: PasqalCloud
+    pasqal_cloud: PasqalCloudConnection
     mock_cloud_client: Any
 
 
@@ -169,7 +169,7 @@ def mock_pasqal_cloud_sdk(mock_batch):
             "region": "fr",
         }
 
-        pasqal_cloud = PasqalCloud(**pasqal_cloud_kwargs)
+        pasqal_cloud = PasqalCloudConnection(**pasqal_cloud_kwargs)
 
         mock_cloud_client.assert_called_once_with(**pasqal_cloud_kwargs)
 

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -6,7 +6,8 @@ from uuid import UUID, uuid4
 import pytest
 import requests
 import requests_mock
-from pasqal_cloud import SDK, Workload
+from pasqal_cloud.pasqal_cloud_client import PasqalCloudClient
+from pasqal_cloud import Workload
 from pasqal_cloud.errors import (
     WorkloadCancellingError,
     WorkloadCreationError,
@@ -30,10 +31,11 @@ class TestWorkload:
 
     @pytest.fixture(autouse=True)
     @patch(
-        "pasqal_cloud.client.PasswordGrantTokenProvider", FakeAuth0AuthenticationSuccess
+        "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+        FakeAuth0AuthenticationSuccess,
     )
     def _init_sdk(self):
-        self.sdk = SDK(
+        self.sdk = PasqalCloudClient(
             username="me@test.com",
             password="password",
             project_id=str(uuid4()),


### PR DESCRIPTION
### Description

- Mark all current pasqal_cloud exported names as deprecated, this will 1) notify users if imported something from root namespace while we don't want to anymore (as we want to expose PasqalCloudConnection/RemoteConnection only now)
- Classes were renamed to better reflect what they are about and alias were created to keep backward compatibility
- E2E tests in public apis were updated to reflect those changes.
- Documentation update will come in the next PR.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
