### PR TITLE
chore: upgrade min python version and packages (public-apis#1797)

### DIFF
--- a/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
+++ b/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout main code and submodules

--- a/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
+++ b/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout main code and submodules
@@ -36,7 +36,7 @@ jobs:
         run: |
           pytest -vvv --cov
 
-      - name: Mypy checks only for Python 3.9
-        if: ${{ matrix.python-version == 3.9 }}
+      - name: Mypy checks only for Python 3.10
+        if: ${{ matrix.python-version == 3.10 }}
         run: |
           mypy

--- a/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
+++ b/.github/workflows/run-tests-and-mypy-and-pre-commit-hooks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install main dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ./pasqal-cloud[dev] ./pulser-pasqal
+          pip install ./pasqal-cloud[dev]
 
       - name: Install and run pre-commit hooks
         run: |

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -26,7 +26,7 @@ from pulser.backend.remote import JobParams, RemoteBackend, RemoteResults
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 
-class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):
+class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[misc]
     _device_type: ClassVar[DeviceTypeName]
 
     def __init__(

--- a/pasqal-cloud/setup.py
+++ b/pasqal-cloud/setup.py
@@ -56,7 +56,7 @@ setup(
     long_description_content_type="text/markdown",
     maintainer="Pasqal Cloud Services",
     maintainer_email="pcs@pasqal.io",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     license="Apache 2.0",
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -68,9 +68,8 @@ setup(
         "requests>=2.25.1, <3.0.0",
         "pyjwt[crypto]>=2.5.0, <3.0.0",
         "pydantic >= 2.6.0, <3.0.0",
-        "requests-mock==1.12.1",
-        "pulser-core >= 1.6",
-        "tenacity ~= 8.5",
+        "pulser-core >= 1.8",
+        "tenacity >= 9.1",
     ],
     extras_require={
         "dev": {
@@ -78,6 +77,7 @@ setup(
             "mypy==1.10.0",
             "pytest==8.1.1",
             "pytest-cov==5.0.0",
+            "requests-mock==1.12.1",
             "types-requests==2.31.0.1",
         },
         "docs": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 
-# Assume Python 3.9
-target-version = "py39"
+# Assume Python 3.10
+target-version = "py310"
 
 [tool.ruff.lint]
 # Rules applied by ruff, more information on https://docs.astral.sh/ruff/rules/
@@ -31,7 +31,17 @@ select = [
     "PERF",
     "RUF",
 ]
-ignore = ["W191", "E111", "E114", "E117", "Q000", "Q001", "Q002", "Q003", "SIM115"]
+ignore = [
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "SIM115",
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
### Description

We drop python 3.9 support because:
- it reaches it's EOL
- it prevents us to upgrade pulser (problematic)
- it prevents us to upgrade tenacity (minor)

As latest pulser versions requires at least python 3.10 there is no reason to keep supporting 3.9 now.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
