### PR TITLE
feat(RemoteEmulatorBackend): map job_params 'runs' to emulator 'default_num_shots' (public-apis#1861)

### DIFF
--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from typing import Any, ClassVar
 
@@ -24,6 +25,8 @@ from pulser.backend import BitStrings, EmulationConfig, EmulatorBackend
 from pulser.backend.remote import JobParams, RemoteBackend, RemoteResults
 
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
+
+logger = logging.getLogger(__name__)
 
 
 class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[misc]
@@ -66,12 +69,17 @@ class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[mis
                 obtained results' status can be checked using their `status`
                 property.
 
-        Warning:
-            Unlike a 'QPUBackend', this backend does not expect a value for
-            "runs" in each entry of 'job_params'. If provided, this value is
-            ignored. If you wish to set the total number of bitstring counts
-            in the Results, please provide a 'BitStrings' observable with the
-            desired 'num_shots' via this backend's 'config' instead."
+        Note on 'runs':
+            Unlike a QPU backend, emulator backends do not use 'runs'
+            directly. Within an open_batch, 'runs' is ignored and a
+            warning is emitted. Outside an open_batch, the highest
+            'runs' value across all jobs is used to set
+            'default_num_shots' on this backend's config (unless a
+            'BitStrings' observable with a custom 'num_shots' is
+            already configured, in which case 'runs' has no effect).
+            To control the number of bitstring samples explicitly,
+            provide a 'BitStrings' observable with the desired
+            'num_shots' via this backend's 'config'.
 
         Returns:
             The results, which can be accessed once all sequences have been
@@ -82,23 +90,70 @@ class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[mis
             # Assume a single job
             _job_params = [{"runs": 1}]
         else:
-            if any(
-                j.get("runs", None) is not None
-                for j in job_params
-                if isinstance(j, dict)
-            ):
-                # Warns whenever runs is defined and not None
+            runs_values: list[int] = [
+                j["runs"] for j in job_params if j.get("runs") is not None
+            ]
+
+            # Inside an open_batch: runs has no effect on emulators.
+            # Reset runs to 1 and warn the user.
+            if self._batch_id and runs_values:
                 warnings.warn(
                     "The 'runs' parameter is ignored on jobs executed on "
-                    f"{self.__class__.__name__!r}. If you wish to set a "
-                    "custom number of bitstring counts in the Results, please "
-                    "provide a 'BitStrings' observable with the desired "
-                    "'num_shots' via this backend's 'config' instead.",
+                    f"{self.__class__.__name__!r} within an open_batch "
+                    "for now. It uses BitStrings observable 'num_shots' "
+                    f"or 'default_num_shots' of {self.__class__.__name__!r}'s config.",
                     stacklevel=2,
                 )
+            elif runs_values:
+                max_runs = max(runs_values)
+                if not self._apply_default_num_shots(max_runs):
+                    warnings.warn(
+                        "The 'runs' parameter has no effect on "
+                        f"{self.__class__.__name__!r} because a "
+                        "'BitStrings' observable with a custom "
+                        "'num_shots' is already configured. The "
+                        "existing 'num_shots' value will be used.",
+                        stacklevel=2,
+                    )
+                elif len(runs_values) > 1:
+                    warnings.warn(
+                        "Passing multiple jobs with 'runs' is not "
+                        "supported on emulator backends for now. "
+                        f"'default_num_shots' has been set to "
+                        f"{max_runs} (the highest 'runs' value) on "
+                        f"{self.__class__.__name__!r}'s config.",
+                        stacklevel=2,
+                    )
+
             # TODO: Stop defaulting runs=1 once it is optional on pasqal-cloud
             _job_params = [{"runs": 1, **j} for j in job_params]
+
         return super().run(job_params=_job_params, wait=wait)
+
+    def _apply_default_num_shots(self, max_runs: int) -> bool:
+        """Set config.default_num_shots from the highest 'runs' value.
+
+        Returns True if default_num_shots was updated, False if a
+        BitStrings observable already has a custom num_shots (in which
+        case runs has no effect).
+        """
+        has_custom_num_shots = any(
+            isinstance(obs, BitStrings) and obs.num_shots is not None
+            for obs in self._config.observables
+        )
+        if has_custom_num_shots:
+            return False
+
+        self._config = self._config.with_changes(
+            default_num_shots=max_runs,
+        )
+        logger.info(
+            "Setting 'default_num_shots' to %d on %s's config "
+            "(derived from the highest 'runs' value).",
+            max_runs,
+            self.__class__.__name__,
+        )
+        return True
 
     def _submit_kwargs(self) -> dict[str, Any]:
         """Keyword arguments given to any call to RemoteConnection.submit()."""

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -1,4 +1,5 @@
-import contextlib
+import json
+import logging
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -13,32 +14,49 @@ from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
 
+# Batch ID that has a matching fixture file under
+# tests/fixtures/core-fast/api/v2/batches/
+MOCK_BATCH_ID = "00000000-0000-0000-0000-000000000001"
+
+
+def _make_backend(connection, config=None):
+    """Helper to build an EmuFreeBackend with a minimal sequence."""
+    device = AnalogDevice
+    register = Register.from_coordinates([(0, 0)], prefix="q")
+    sequence = Sequence(register, device)
+    sequence.declare_channel("rydberg_global", "rydberg_global")
+    sequence.measure()
+    return EmuFreeBackend(
+        sequence=sequence, connection=connection, config=config
+    ), sequence
+
 
 @patch(
     "pasqal_cloud.http_client.PasswordGrantTokenProvider",
     FakeAuth0AuthenticationSuccess,
 )
-@pytest.mark.parametrize("job_params", [None, [JobParams(runs=10)]])
-def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params):
+@pytest.mark.parametrize(
+    ("job_params", "expected_default_num_shots"),
+    [
+        pytest.param(None, None, id="no_job_params"),
+        pytest.param([JobParams(runs=10)], 10, id="runs_10"),
+    ],
+)
+def test_emu_free_backend(
+    mock_request: requests_mock.mocker.Mocker,
+    caplog,
+    job_params,
+    expected_default_num_shots,
+):
     mock_request.reset_mock()
     connection = PasqalCloudConnection(
         username="test", password="test", project_id=str(uuid4())
     )
 
-    device = AnalogDevice
-    register = Register.from_coordinates([(0, 0)], prefix="q")
-    sequence = Sequence(register, device)
-    # Just to avoid warning when measure() is called
-    sequence.declare_channel("rydberg_global", "rydberg_global")
-    sequence.measure()
-
-    backend = EmuFreeBackend(sequence=sequence, connection=connection)
-    context_manager = (
-        pytest.warns(UserWarning, match="'runs' parameter is ignored")
-        if job_params
-        else contextlib.nullcontext()
-    )
-    with context_manager:
+    backend, sequence = _make_backend(connection)
+    # Outside an open_batch with runs should NOT warn (it sets
+    # default_num_shots instead), and without runs should not warn either.
+    with caplog.at_level(logging.INFO, logger="pasqal_cloud.backends"):
         _ = backend.run(job_params=job_params)
     assert (
         mock_request.request_history[0].url
@@ -48,12 +66,25 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     post_batch_body = mock_request.request_history[0].json()
     assert post_batch_body["device_type"] == "EMU_FREE"
     assert post_batch_body["sequence_builder"] == sequence.to_abstract_repr()
-    assert (
-        post_batch_body["backend_configuration"]
-        == EmuFreeBackend.default_config.to_abstract_repr()
-    )
     assert "emulator" not in post_batch_body
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
+
+    # When runs is provided, default_num_shots is set on the config;
+    # otherwise the default config is sent unchanged.
+    if expected_default_num_shots is not None:
+        expected_config = EmuFreeBackend.default_config.with_changes(
+            default_num_shots=expected_default_num_shots,
+        )
+        assert any(
+            "Setting 'default_num_shots'" in r.message
+            and str(expected_default_num_shots) in r.message
+            for r in caplog.records
+        ), f"Expected INFO log with default_num_shots={expected_default_num_shots}"
+    else:
+        expected_config = EmuFreeBackend.default_config
+    assert (
+        post_batch_body["backend_configuration"] == expected_config.to_abstract_repr()
+    )
 
 
 @patch(
@@ -66,15 +97,8 @@ def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.
         username="test", password="test", project_id=str(uuid4())
     )
 
-    device = AnalogDevice
-    register = Register.from_coordinates([(0, 0)], prefix="q")
-    sequence = Sequence(register, device)
-    # Just to avoid warning when measure() is called
-    sequence.declare_channel("rydberg_global", "rydberg_global")
-    sequence.measure()
-
     config = EmulationConfig(observables=[BitStrings(), CorrelationMatrix()])
-    backend = EmuFreeBackend(sequence=sequence, connection=connection, config=config)
+    backend, sequence = _make_backend(connection, config=config)
     _ = backend.run()
     assert (
         mock_request.request_history[0].url
@@ -86,3 +110,168 @@ def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.
     assert post_batch_body["sequence_builder"] == sequence.to_abstract_repr()
     assert post_batch_body["backend_configuration"] == config.to_abstract_repr()
     assert "emulator" not in post_batch_body
+
+
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
+def test_no_open_batch_one_job_sets_default_num_shots(
+    mock_request: requests_mock.mocker.Mocker,
+    caplog,
+):
+    """Outside an open_batch, a single job with runs should set
+    default_num_shots without any warning."""
+    mock_request.reset_mock()
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
+    backend, _ = _make_backend(connection)
+
+    with caplog.at_level(logging.INFO, logger="pasqal_cloud.backends"):
+        _ = backend.run(job_params=[JobParams(runs=200)])
+
+    post_batch_body = mock_request.request_history[0].json()
+    config_sent = json.loads(post_batch_body["backend_configuration"])
+    assert config_sent.get("default_num_shots") == 200
+
+    assert any(
+        "Setting 'default_num_shots'" in record.message and "200" in record.message
+        for record in caplog.records
+    ), "Expected INFO log with default_num_shots=200"
+
+
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
+@pytest.mark.parametrize(
+    ("job_params", "expected_default_num_shots"),
+    [
+        pytest.param(
+            [JobParams(runs=50, variables={})] * 3,
+            50,
+            id="multiple_jobs_same_runs",
+        ),
+        pytest.param(
+            [
+                JobParams(runs=10, variables={}),
+                JobParams(runs=100, variables={}),
+                JobParams(runs=50, variables={}),
+            ],
+            100,
+            id="multiple_jobs_different_runs_takes_highest",
+        ),
+    ],
+)
+def test_no_open_batch_multiple_jobs_warns_and_sets_default_num_shots(
+    mock_request: requests_mock.mocker.Mocker,
+    caplog,
+    job_params,
+    expected_default_num_shots,
+):
+    """Outside an open_batch, multiple jobs with runs should warn that
+    this is not supported for now, and set default_num_shots to the
+    highest value."""
+    mock_request.reset_mock()
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
+    backend, _ = _make_backend(connection)
+
+    with (
+        caplog.at_level(logging.INFO, logger="pasqal_cloud.backends"),
+        pytest.warns(
+            UserWarning,
+            match="Passing multiple jobs with 'runs' is not supported",
+        ),
+    ):
+        _ = backend.run(job_params=job_params)
+
+    post_batch_body = mock_request.request_history[0].json()
+    config_sent = json.loads(post_batch_body["backend_configuration"])
+    assert config_sent.get("default_num_shots") == expected_default_num_shots
+
+    assert any(
+        "Setting 'default_num_shots'" in record.message
+        and str(expected_default_num_shots) in record.message
+        for record in caplog.records
+    ), f"Expected INFO log with default_num_shots={expected_default_num_shots}"
+
+
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
+def test_no_open_batch_custom_num_shots_warns_runs_ignored(
+    mock_request: requests_mock.mocker.Mocker,
+):
+    """Outside an open_batch, if BitStrings already has a custom num_shots,
+    passing runs should emit a warning that runs has no effect."""
+    mock_request.reset_mock()
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
+    config = EmulationConfig(observables=[BitStrings(num_shots=500)])
+    backend, _ = _make_backend(connection, config=config)
+
+    with pytest.warns(UserWarning, match="'runs' parameter has no effect"):
+        _ = backend.run(job_params=[JobParams(runs=100)])
+
+
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
+@pytest.mark.parametrize(
+    "job_params",
+    [
+        pytest.param(
+            [JobParams(runs=50, variables={})] * 3,
+            id="multiple_jobs_with_runs",
+        ),
+        pytest.param(
+            [JobParams(runs=200)],
+            id="one_job_with_runs",
+        ),
+    ],
+)
+def test_open_batch_with_runs_warns(
+    mock_request: requests_mock.mocker.Mocker,
+    job_params,
+):
+    """Inside an open_batch, any job with runs should warn."""
+    mock_request.reset_mock()
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
+    backend, _ = _make_backend(connection)
+    backend._batch_id = MOCK_BATCH_ID
+
+    with pytest.warns(UserWarning, match="'runs' parameter is ignored"):
+        _ = backend.run(job_params=job_params)
+
+
+@patch(
+    "pasqal_cloud.http_client.PasswordGrantTokenProvider",
+    FakeAuth0AuthenticationSuccess,
+)
+def test_open_batch_no_runs_no_warning(
+    mock_request: requests_mock.mocker.Mocker,
+    recwarn,
+):
+    """Inside an open_batch, if no runs are specified, no warning."""
+    mock_request.reset_mock()
+    connection = PasqalCloudConnection(
+        username="test", password="test", project_id=str(uuid4())
+    )
+    backend, _ = _make_backend(connection)
+    backend._batch_id = MOCK_BATCH_ID
+
+    _ = backend.run(job_params=[JobParams(variables={})])
+
+    # Assert no UserWarning was emitted
+    user_warnings = [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+    assert (
+        len(user_warnings) == 0
+    ), f"Expected no UserWarning but got: {[str(w.message) for w in user_warnings]}"

--- a/tests/backend/test_emu_mps.py
+++ b/tests/backend/test_emu_mps.py
@@ -1,6 +1,6 @@
-import contextlib
 import dataclasses
 import json
+import logging
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -27,12 +27,24 @@ test_device = dataclasses.replace(
 @pytest.mark.parametrize(
     "config", [None, EmulationConfig(observables=[BitStrings(tag_suffix="custom")])]
 )
-@pytest.mark.parametrize("job_params", [None, [JobParams(runs=10)]])
+@pytest.mark.parametrize(
+    ("job_params", "expected_default_num_shots"),
+    [
+        pytest.param(None, None, id="no_job_params"),
+        pytest.param([JobParams(runs=10)], 10, id="runs_10"),
+    ],
+)
 @patch(
     "pasqal_cloud.http_client.PasswordGrantTokenProvider",
     FakeAuth0AuthenticationSuccess,
 )
-def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, config):
+def test_emu_mps_backend(
+    mock_request: requests_mock.mocker.Mocker,
+    caplog,
+    job_params,
+    expected_default_num_shots,
+    config,
+):
     mock_request.reset_mock()
     connection = PasqalCloudConnection(
         username="test", password="test", project_id=str(uuid4())
@@ -47,12 +59,7 @@ def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, 
 
     backend = EmuMPSBackend(sequence=sequence, connection=connection, config=config)
 
-    context_manager = (
-        pytest.warns(UserWarning, match="'runs' parameter is ignored")
-        if job_params
-        else contextlib.nullcontext()
-    )
-    with context_manager:
+    with caplog.at_level(logging.INFO, logger="pasqal_cloud.backends"):
         _ = backend.run(job_params=job_params)
     assert (
         mock_request.request_history[0].url
@@ -69,7 +76,12 @@ def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, 
         (EmuMPSBackend.default_config).to_abstract_repr()
     )
     custom_config_params = json.loads(config.to_abstract_repr()) if config else {}
-    assert (
-        json.loads(post_batch_body["backend_configuration"])
-        == default_config_params | custom_config_params
-    )
+    expected_config = default_config_params | custom_config_params
+    if expected_default_num_shots is not None:
+        expected_config["default_num_shots"] = expected_default_num_shots
+        assert any(
+            "Setting 'default_num_shots'" in r.message
+            and str(expected_default_num_shots) in r.message
+            for r in caplog.records
+        ), f"Expected INFO log with default_num_shots={expected_default_num_shots}"
+    assert json.loads(post_batch_body["backend_configuration"]) == expected_config


### PR DESCRIPTION
### Description

Previously, the 'runs' parameter on emulator backends was silently ignored with a blanket warning. This change makes 'runs' meaningful outside of an open_batch by mapping it to the EmulationConfig's 'default_num_shots' setting.

Behavior summary:
- Outside an open_batch (single job): sets default_num_shots to the provided runs value.
- Outside an open_batch (multiple jobs): sets default_num_shots to the highest runs value and warns that per-job runs is not yet supported.
- Outside an open_batch with a custom BitStrings num_shots already set: warns that runs has no effect and preserves the existing num_shots.
- Inside an open_batch: resets runs to 1 and warns, since runs has no effect on emulators in that context.


#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
