### PR TITLE
typing: RemoteEmulatorBackend requires any RemoteConnection (public-apis#1853)

### DIFF
--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -21,9 +21,12 @@ from typing import Any, ClassVar
 import pulser
 from pasqal_cloud.device.device_types import DeviceTypeName
 from pulser.backend import BitStrings, EmulationConfig, EmulatorBackend
-from pulser.backend.remote import JobParams, RemoteBackend, RemoteResults
-
-from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
+from pulser.backend.remote import (
+    JobParams,
+    RemoteBackend,
+    RemoteConnection,
+    RemoteResults,
+)
 
 
 class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[misc]
@@ -32,7 +35,7 @@ class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[mis
     def __init__(
         self,
         sequence: pulser.Sequence,
-        connection: PasqalCloudConnection,
+        connection: RemoteConnection,
         *,
         config: EmulationConfig | None = None,
         mimic_qpu: bool = False,


### PR DESCRIPTION
### Description

This is "needed" (it's a typing issue only) in order for pulser-azure to be able to use those backends

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
