### PR TITLE
[FIX]: wait argument in open batch is now blocking when set to True

### DIFF
--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_client.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_client.py
@@ -638,7 +638,9 @@ class PasqalCloudClient:
                 job_rsp = self._get_job(id)
         return Job(**job_rsp, _client=self._client)
 
-    def add_jobs(self, batch_id: str, jobs: List[CreateJob]) -> Batch:
+    def add_jobs(
+        self, batch_id: str, jobs: List[CreateJob], wait: bool = False
+    ) -> Batch:
         """
         Add jobs to an already existing batch.
 
@@ -657,7 +659,16 @@ class PasqalCloudClient:
             resp = self._client.add_jobs(batch_id, create_jobs_to_api_payload(jobs))
         except HTTPError as e:
             raise JobCreationError(e)
-        return Batch(**resp, _client=self._client)
+
+        batch = Batch(**resp, _client=self._client)
+
+        if wait:
+            while any(
+                job.status in {"PENDING", "RUNNING"} for job in batch.ordered_jobs
+            ):
+                time.sleep(RESULT_POLLING_INTERVAL)
+                batch.refresh()
+        return batch
 
     def complete_batch(self, batch_id: str) -> Batch:
         """

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
@@ -109,7 +109,8 @@ class PasqalCloudConnection(RemoteConnection):
             old_job_ids = self._get_job_ids(batch_id)
             batch = submit_jobs_fn(
                 batch_id,
-                jobs=job_params,
+                jobs = job_params,
+                wait = wait,
             )
             new_job_ids = [
                 job_id

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
@@ -109,8 +109,8 @@ class PasqalCloudConnection(RemoteConnection):
             old_job_ids = self._get_job_ids(batch_id)
             batch = submit_jobs_fn(
                 batch_id,
-                jobs = job_params,
-                wait = wait,
+                jobs=job_params,
+                wait=wait,
             )
             new_job_ids = [
                 job_id

--- a/tests/test_remote_connections.py
+++ b/tests/test_remote_connections.py
@@ -379,6 +379,7 @@ def test_submit(fixt_pasqal_cloud, parametrized, mimic_qpu, seq, mock_batch):
     fixt_pasqal_cloud.mock_cloud_client.add_jobs.assert_called_once_with(
         "open_batch",
         jobs=job_params,
+        wait=False,
     )
     # The MockBatch returned before and after submission is the same
     # so no new job ids are found


### PR DESCRIPTION
### Description

<!-- What has changed and why has it changed -->
Fixed the non blocking wait argument when calling the method `run` within an `open_batch` context manager with `wait = True`.
#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [X] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [X] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [X] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [X] Unit tests have been added or adjusted.
- [X] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [X] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [X] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
