### PR TITLE
chore: rename EmuX by RemoteXBackend

### DIFF
--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -15,15 +15,15 @@ from typing import Any
 
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 from pasqal_cloud.ovh import OVHConnection
-from pasqal_cloud.backends import EmuMPSBackend, EmuSVBackend, EmuFreeBackend
+from pasqal_cloud.backends import RemoteMPSBackend, RemoteSVBackend, RemoteFreeBackend
 
 # Public API — only these two are the intended top-level exports.
 __all__ = [
     "PasqalCloudConnection",
     "OVHConnection",
-    "EmuMPSBackend",
-    "EmuSVBackend",
-    "EmuFreeBackend",
+    "RemoteMPSBackend",
+    "RemoteSVBackend",
+    "RemoteFreeBackend",
 ]
 
 

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 from pasqal_cloud.ovh import OVHConnection
-from pasqal_cloud.backends import RemoteMPSBackend, RemoteSVBackend, RemoteFreeBackend
+from pasqal_cloud.backends import RemoteMPSBackend, RemoteSVBackend, RemoteQutipBackend
 
 # Public API — only these two are the intended top-level exports.
 __all__ = [
@@ -23,7 +23,7 @@ __all__ = [
     "OVHConnection",
     "RemoteMPSBackend",
     "RemoteSVBackend",
-    "RemoteFreeBackend",
+    "RemoteQutipBackend",
 ]
 
 

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -112,7 +112,7 @@ class RemoteEmulatorBackend(RemoteBackend, EmulatorBackend):  # type: ignore[mis
         )
 
 
-class EmuMPSBackend(RemoteEmulatorBackend):
+class RemoteMPSBackend(RemoteEmulatorBackend):
     """
     Backend for executing quantum programs using the EMU-MPS emulator.
 
@@ -138,7 +138,7 @@ class EmuMPSBackend(RemoteEmulatorBackend):
     _device_type = DeviceTypeName.EMU_MPS
 
 
-class EmuSVBackend(RemoteEmulatorBackend):
+class RemoteSVBackend(RemoteEmulatorBackend):
     """
     Backend for executing quantum programs using the EMU-SV emulator.
 
@@ -161,7 +161,7 @@ class EmuSVBackend(RemoteEmulatorBackend):
     _device_type = DeviceTypeName.EMU_SV
 
 
-class EmuFreeBackend(RemoteEmulatorBackend):
+class RemoteFreeBackend(RemoteEmulatorBackend):
     """
     Backend for executing quantum programs using pulser-simulation (QuTiP).
 

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -161,7 +161,7 @@ class RemoteSVBackend(RemoteEmulatorBackend):
     _device_type = DeviceTypeName.EMU_SV
 
 
-class RemoteFreeBackend(RemoteEmulatorBackend):
+class RemoteQutipBackend(RemoteEmulatorBackend):
     """
     Backend for executing quantum programs using pulser-simulation (QuTiP).
 

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -8,7 +8,7 @@ from pulser import AnalogDevice, Register, Sequence
 from pulser.backend import BitStrings, CorrelationMatrix
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
-from pasqal_cloud.backends import RemoteFreeBackend
+from pasqal_cloud.backends import RemoteQutipBackend
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -32,7 +32,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     sequence.declare_channel("rydberg_global", "rydberg_global")
     sequence.measure()
 
-    backend = RemoteFreeBackend(sequence=sequence, connection=connection)
+    backend = RemoteQutipBackend(sequence=sequence, connection=connection)
     context_manager = (
         pytest.warns(UserWarning, match="'runs' parameter is ignored")
         if job_params
@@ -50,7 +50,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     assert post_batch_body["sequence_builder"] == sequence.to_abstract_repr()
     assert (
         post_batch_body["backend_configuration"]
-        == RemoteFreeBackend.default_config.to_abstract_repr()
+        == RemoteQutipBackend.default_config.to_abstract_repr()
     )
     assert "emulator" not in post_batch_body
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
@@ -74,7 +74,9 @@ def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.
     sequence.measure()
 
     config = EmulationConfig(observables=[BitStrings(), CorrelationMatrix()])
-    backend = RemoteFreeBackend(sequence=sequence, connection=connection, config=config)
+    backend = RemoteQutipBackend(
+        sequence=sequence, connection=connection, config=config
+    )
     _ = backend.run()
     assert (
         mock_request.request_history[0].url

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -8,7 +8,7 @@ from pulser import AnalogDevice, Register, Sequence
 from pulser.backend import BitStrings, CorrelationMatrix
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
-from pasqal_cloud.backends import EmuFreeBackend
+from pasqal_cloud.backends import RemoteFreeBackend
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -32,7 +32,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     sequence.declare_channel("rydberg_global", "rydberg_global")
     sequence.measure()
 
-    backend = EmuFreeBackend(sequence=sequence, connection=connection)
+    backend = RemoteFreeBackend(sequence=sequence, connection=connection)
     context_manager = (
         pytest.warns(UserWarning, match="'runs' parameter is ignored")
         if job_params
@@ -50,7 +50,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     assert post_batch_body["sequence_builder"] == sequence.to_abstract_repr()
     assert (
         post_batch_body["backend_configuration"]
-        == EmuFreeBackend.default_config.to_abstract_repr()
+        == RemoteFreeBackend.default_config.to_abstract_repr()
     )
     assert "emulator" not in post_batch_body
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
@@ -74,7 +74,7 @@ def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.
     sequence.measure()
 
     config = EmulationConfig(observables=[BitStrings(), CorrelationMatrix()])
-    backend = EmuFreeBackend(sequence=sequence, connection=connection, config=config)
+    backend = RemoteFreeBackend(sequence=sequence, connection=connection, config=config)
     _ = backend.run()
     assert (
         mock_request.request_history[0].url

--- a/tests/backend/test_emu_mps.py
+++ b/tests/backend/test_emu_mps.py
@@ -9,7 +9,7 @@ import requests_mock
 from pulser import AnalogDevice, DigitalAnalogDevice, Register, Sequence
 from pulser.backend import BitStrings, EmulationConfig
 from pulser.backend.remote import JobParams
-from pasqal_cloud.backends import EmuMPSBackend
+from pasqal_cloud.backends import RemoteMPSBackend
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -45,7 +45,7 @@ def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, 
     sequence.declare_channel("rydberg_global", "rydberg_global")
     sequence.measure()
 
-    backend = EmuMPSBackend(sequence=sequence, connection=connection, config=config)
+    backend = RemoteMPSBackend(sequence=sequence, connection=connection, config=config)
 
     context_manager = (
         pytest.warns(UserWarning, match="'runs' parameter is ignored")
@@ -66,7 +66,7 @@ def test_emu_mps_backend(mock_request: requests_mock.mocker.Mocker, job_params, 
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
 
     default_config_params = json.loads(
-        (EmuMPSBackend.default_config).to_abstract_repr()
+        (RemoteMPSBackend.default_config).to_abstract_repr()
     )
     custom_config_params = json.loads(config.to_abstract_repr()) if config else {}
     assert (

--- a/tests/backend/test_emu_sv.py
+++ b/tests/backend/test_emu_sv.py
@@ -6,7 +6,7 @@ import requests_mock
 from pulser import AnalogDevice, DigitalAnalogDevice, Register, Sequence
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
-from pasqal_cloud.backends import EmuSVBackend
+from pasqal_cloud.backends import RemoteSVBackend
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -37,7 +37,7 @@ def test_emu_sv_backend(mock_request: requests_mock.mocker.Mocker):
     sequence.measure()
 
     config = EmulationConfig()
-    backend = EmuSVBackend(sequence=sequence, connection=connection, config=config)
+    backend = RemoteSVBackend(sequence=sequence, connection=connection, config=config)
     _ = backend.run(job_params=[JobParams(runs=10)])
     assert (
         mock_request.request_history[0].url


### PR DESCRIPTION
### Description

We rename all those backends to have a consistent naming with their local counterpart and prevent an issue with EmuFreeBackend renaming causing issues in https://github.com/pasqal-io/Pulser/pull/1063

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
