### PR TITLE
Rename RemoteQutipBackend to RemoteEmuFreeBackend

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ The package exposes several remote emulator backends:
 
 - [`RemoteSVBackend`][pasqal_cloud.RemoteSVBackend] — state vector emulator
 - [`RemoteMPSBackend`][pasqal_cloud.RemoteMPSBackend] — matrix product states emulator
-- [`RemoteQutipBackend`][pasqal_cloud.RemoteQutipBackend] — qutip emulator
+- [`RemoteFreeBackend`][pasqal_cloud.RemoteFreeBackend] — qutip emulator
 
 Use them in place of `QPUBackend` to run the same sequences without consuming
 real QPU time:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ The package exposes several remote emulator backends:
 
 - [`RemoteSVBackend`][pasqal_cloud.RemoteSVBackend] — state vector emulator
 - [`RemoteMPSBackend`][pasqal_cloud.RemoteMPSBackend] — matrix product states emulator
-- [`RemoteFreeBackend`][pasqal_cloud.RemoteFreeBackend] — qutip emulator
+- [`RemoteEmuFreeBackend`][pasqal_cloud.RemoteEmuFreeBackend] — qutip emulator
 
 Use them in place of `QPUBackend` to run the same sequences without consuming
 real QPU time:

--- a/docs/migrating-from-pulser-pasqal.md
+++ b/docs/migrating-from-pulser-pasqal.md
@@ -6,7 +6,7 @@ Replace your `pulser_pasqal` imports with `pasqal_cloud` and use the new classes
 | `OVHConnection` | `OVHConnection` |
 | `EmuMPSBackend` | `RemoteMPSBackend` |
 | `EmuSVBackend` | `RemoteSVBackend` |
-| `EmuFreeBackendV2` | `RemoteFreeBackend` |
+| `EmuFreeBackendV2` | `RemoteEmuFreeBackend` |
 
 For example:
 

--- a/docs/migrating-from-pulser-pasqal.md
+++ b/docs/migrating-from-pulser-pasqal.md
@@ -6,7 +6,7 @@ Replace your `pulser_pasqal` imports with `pasqal_cloud` and use the new classes
 | `OVHConnection` | `OVHConnection` |
 | `EmuMPSBackend` | `RemoteMPSBackend` |
 | `EmuSVBackend` | `RemoteSVBackend` |
-| `EmuFreeBackendV2` | `RemoteQutipBackend` |
+| `EmuFreeBackendV2` | `RemoteFreeBackend` |
 
 For example:
 

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -15,7 +15,11 @@ from typing import Any
 
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 from pasqal_cloud.ovh import OVHConnection
-from pasqal_cloud.backends import RemoteMPSBackend, RemoteSVBackend, RemoteFreeBackend
+from pasqal_cloud.backends import (
+    RemoteMPSBackend,
+    RemoteSVBackend,
+    RemoteEmuFreeBackend,
+)
 
 # Public API — only these two are the intended top-level exports.
 __all__ = [
@@ -23,7 +27,7 @@ __all__ = [
     "OVHConnection",
     "RemoteMPSBackend",
     "RemoteSVBackend",
-    "RemoteFreeBackend",
+    "RemoteEmuFreeBackend",
 ]
 
 

--- a/pasqal-cloud/pasqal_cloud/__init__.py
+++ b/pasqal-cloud/pasqal_cloud/__init__.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 from pasqal_cloud.ovh import OVHConnection
-from pasqal_cloud.backends import RemoteMPSBackend, RemoteSVBackend, RemoteQutipBackend
+from pasqal_cloud.backends import RemoteMPSBackend, RemoteSVBackend, RemoteFreeBackend
 
 # Public API — only these two are the intended top-level exports.
 __all__ = [
@@ -23,7 +23,7 @@ __all__ = [
     "OVHConnection",
     "RemoteMPSBackend",
     "RemoteSVBackend",
-    "RemoteQutipBackend",
+    "RemoteFreeBackend",
 ]
 
 

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -120,7 +120,7 @@ class RemoteSVBackend(RemoteEmulatorBackend):
     _device_type = DeviceTypeName.EMU_SV
 
 
-class RemoteQutipBackend(RemoteEmulatorBackend):
+class RemoteFreeBackend(RemoteEmulatorBackend):
     """
     Backend for executing quantum programs using pulser-simulation (QuTiP).
 

--- a/pasqal-cloud/pasqal_cloud/backends.py
+++ b/pasqal-cloud/pasqal_cloud/backends.py
@@ -120,7 +120,7 @@ class RemoteSVBackend(RemoteEmulatorBackend):
     _device_type = DeviceTypeName.EMU_SV
 
 
-class RemoteFreeBackend(RemoteEmulatorBackend):
+class RemoteEmuFreeBackend(RemoteEmulatorBackend):
     """
     Backend for executing quantum programs using pulser-simulation (QuTiP).
 

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -1,4 +1,3 @@
-import contextlib
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -8,7 +7,7 @@ from pulser import AnalogDevice, Register, Sequence
 from pulser.backend import BitStrings, CorrelationMatrix
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
-from pasqal_cloud.backends import RemoteQutipBackend
+from pasqal_cloud.backends import RemoteFreeBackend
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -32,7 +31,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     sequence.declare_channel("rydberg_global", "rydberg_global")
     sequence.measure()
 
-    backend = RemoteQutipBackend(sequence=sequence, connection=connection)
+    backend = RemoteFreeBackend(sequence=sequence, connection=connection)
     _ = backend.run(job_params=job_params)
     assert (
         mock_request.request_history[0].url
@@ -44,7 +43,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     assert post_batch_body["sequence_builder"] == sequence.to_abstract_repr()
     assert (
         post_batch_body["backend_configuration"]
-        == RemoteQutipBackend.default_config.to_abstract_repr()
+        == RemoteFreeBackend.default_config.to_abstract_repr()
     )
     assert "emulator" not in post_batch_body
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
@@ -68,9 +67,7 @@ def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.
     sequence.measure()
 
     config = EmulationConfig(observables=[BitStrings(), CorrelationMatrix()])
-    backend = RemoteQutipBackend(
-        sequence=sequence, connection=connection, config=config
-    )
+    backend = RemoteFreeBackend(sequence=sequence, connection=connection, config=config)
     _ = backend.run()
     assert (
         mock_request.request_history[0].url

--- a/tests/backend/test_emu_free.py
+++ b/tests/backend/test_emu_free.py
@@ -7,7 +7,7 @@ from pulser import AnalogDevice, Register, Sequence
 from pulser.backend import BitStrings, CorrelationMatrix
 from pulser.backend.config import EmulationConfig
 from pulser.backend.remote import JobParams
-from pasqal_cloud.backends import RemoteFreeBackend
+from pasqal_cloud.backends import RemoteEmuFreeBackend
 from pasqal_cloud.pasqal_cloud_connection import PasqalCloudConnection
 
 from tests.test_doubles.authentication import FakeAuth0AuthenticationSuccess
@@ -31,7 +31,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     sequence.declare_channel("rydberg_global", "rydberg_global")
     sequence.measure()
 
-    backend = RemoteFreeBackend(sequence=sequence, connection=connection)
+    backend = RemoteEmuFreeBackend(sequence=sequence, connection=connection)
     _ = backend.run(job_params=job_params)
     assert (
         mock_request.request_history[0].url
@@ -43,7 +43,7 @@ def test_emu_free_backend(mock_request: requests_mock.mocker.Mocker, job_params)
     assert post_batch_body["sequence_builder"] == sequence.to_abstract_repr()
     assert (
         post_batch_body["backend_configuration"]
-        == RemoteFreeBackend.default_config.to_abstract_repr()
+        == RemoteEmuFreeBackend.default_config.to_abstract_repr()
     )
     assert "emulator" not in post_batch_body
     assert post_batch_body["jobs"] == job_params or {"runs": 1}
@@ -67,7 +67,9 @@ def test_emu_free_backend_with_custom_config(mock_request: requests_mock.mocker.
     sequence.measure()
 
     config = EmulationConfig(observables=[BitStrings(), CorrelationMatrix()])
-    backend = RemoteFreeBackend(sequence=sequence, connection=connection, config=config)
+    backend = RemoteEmuFreeBackend(
+        sequence=sequence, connection=connection, config=config
+    )
     _ = backend.run()
     assert (
         mock_request.request_history[0].url


### PR DESCRIPTION
### Description

`RemoteQutipBackend` can't really be used due to naming mismatch with what we have in the user/doc portal and azure

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
