### PR TITLE
[FEAT] improve batch/job status polling mechanism (public-apis#1875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Next release
 
+### pasqal-cloud
+
+* Result polling on batches and jobs use new status endpoints
+
 
 ## [0.23.0]
 

--- a/pasqal-cloud/pasqal_cloud/batch.py
+++ b/pasqal-cloud/pasqal_cloud/batch.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any, Dict, List, Optional, Type, Union
 from warnings import warn
 
@@ -21,6 +20,7 @@ from pasqal_cloud.errors import (
     JobRetryError,
 )
 from pasqal_cloud.job import create_jobs_to_api_payload, CreateJob, Job
+from pasqal_cloud.utils.polling import batch_still_running, poll_status
 
 RESULT_POLLING_INTERVAL = 2  # seconds
 
@@ -194,11 +194,8 @@ class Batch(BaseModel):
         self._update_from_api_response(batch_rsp)
 
         if wait:
-            while any(
-                job.status in {"PENDING", "RUNNING"} for job in self.ordered_jobs
-            ):
-                time.sleep(RESULT_POLLING_INTERVAL)
-                self.refresh()
+            self._wait_for_terminal()
+            self.refresh()
 
     def retry(self, job: Job, wait: bool = False) -> None:
         """
@@ -251,11 +248,8 @@ class Batch(BaseModel):
             raise BatchClosingError(e) from e
         self._update_from_api_response(batch_rsp)
         if wait or fetch_results:
-            while any(
-                job.status in {"PENDING", "RUNNING"} for job in self.ordered_jobs
-            ):
-                time.sleep(RESULT_POLLING_INTERVAL)
-                self.refresh()
+            self._wait_for_terminal()
+            self.refresh()
 
     def cancel(self) -> None:
         """Cancel the current batch on the PCS."""
@@ -272,6 +266,17 @@ class Batch(BaseModel):
         except HTTPError as e:
             raise BatchFetchingError(e) from e
         self._update_from_api_response(batch_rsp)
+
+    def _wait_for_terminal(self) -> None:
+        """Poll the batch-status endpoint until no PENDING/RUNNING jobs remain."""
+
+        def fetch_status() -> Dict[str, Any]:
+            try:
+                return self._client.get_batch_status(self.id)
+            except HTTPError as e:
+                raise BatchFetchingError(e) from e
+
+        poll_status(fetcher=fetch_status, should_continue=batch_still_running)
 
     def _update_from_api_response(self, data: Dict[str, Any]) -> None:
         """Update the instance in place with the response body of the batch API"""

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -109,6 +109,8 @@ class HTTPClient:
             # Batch endpoints
             "send_batch": f"{self.endpoints.core}/api/v1/batches",
             "get_batch": f"{self.endpoints.core}/api/v2/batches/{{batch_id}}",
+            "get_batch_status": f"{self.endpoints.core}/api/v1/"
+            f"batches/{{batch_id}}/status",
             "close_batch": f"{self.endpoints.core}/api/v2/"
             f"batches/{{batch_id}}/complete",
             "cancel_batch": f"{self.endpoints.core}/api/v2/batches/{{batch_id}}/cancel",
@@ -122,6 +124,7 @@ class HTTPClient:
             # Job endpoints
             "get_jobs": f"{self.endpoints.core}/api/v2/jobs",
             "get_job": f"{self.endpoints.core}/api/v2/jobs/{{job_id}}",
+            "get_job_status": f"{self.endpoints.core}/api/v1/jobs/{{job_id}}/status",
             "cancel_job": f"{self.endpoints.core}/api/v2/jobs/{{job_id}}/cancel",
             "get_job_results_link": f"{self.endpoints.core}/api/v1/"
             f"jobs/{{job_id}}/results_link",
@@ -333,6 +336,12 @@ class HTTPClient:
         )["data"]
         return response
 
+    def get_batch_status(self, batch_id: str) -> Dict[str, Any]:
+        response: Dict[str, Any] = self._authenticated_request(
+            "GET", self._get_url("get_batch_status", batch_id=batch_id)
+        )["data"]
+        return response
+
     def get_batch_jobs(self, batch_id: str) -> list[Dict[str, Any]]:
         return self._request_all_pages(
             "GET",
@@ -437,6 +446,12 @@ class HTTPClient:
     def get_job(self, job_id: str) -> Dict[str, Any]:
         response: Dict[str, Any] = self._authenticated_request(
             "GET", self._get_url("get_job", job_id=job_id)
+        )["data"]
+        return response
+
+    def get_job_status(self, job_id: str) -> Dict[str, Any]:
+        response: Dict[str, Any] = self._authenticated_request(
+            "GET", self._get_url("get_job_status", job_id=job_id)
         )["data"]
         return response
 

--- a/pasqal-cloud/pasqal_cloud/ovh.py
+++ b/pasqal-cloud/pasqal_cloud/ovh.py
@@ -32,9 +32,11 @@ class OvhClient(HTTPClient):
             # Batch endpoints
             "send_batch": f"{base_url}/batches",
             "get_batch": f"{base_url}/batches/{{batch_id}}",
+            "get_batch_status": f"{base_url}/batches/{{batch_id}}/status",
             # Job endpoints
             "get_jobs": f"{base_url}/jobs",
             "get_job_results_link": f"{base_url}/jobs/{{job_id}}/results_link",
+            "get_job_status": f"{base_url}/jobs/{{job_id}}/status",
             # Device endpoints
             "get_public_devices_specs": f"{self.endpoints.core}"
             f"/api/v1/devices/public-specs",

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_client.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_client.py
@@ -35,12 +35,18 @@ from pasqal_cloud.errors import (
 )
 from pasqal_cloud.job import CreateJob, Job, create_jobs_to_api_payload
 from pasqal_cloud.project import Project
+from pasqal_cloud.utils.constants import BatchStatus, JobStatus
 from pasqal_cloud.utils.filters import (
     BatchFilters,
     CancelJobFilters,
     JobFilters,
     PaginationParams,
     RebatchFilters,
+)
+from pasqal_cloud.utils.polling import (
+    batch_still_running,
+    job_still_running,
+    poll_status,
 )
 from pasqal_cloud.utils.responses import (
     BatchCancellationResponse,
@@ -166,6 +172,33 @@ class PasqalCloudClient:
             return self._client.get_batch(id)
         except HTTPError as e:
             raise BatchFetchingError(e) from e
+
+    def _get_batch_status(self, id: str) -> Dict[str, Any]:
+        try:
+            return self._client.get_batch_status(id)
+        except HTTPError as e:
+            raise BatchFetchingError(e) from e
+
+    def _wait_for_batch_terminal(self, id: str) -> None:
+        """Poll the batch-status endpoint until no PENDING/RUNNING jobs remain."""
+        poll_status(
+            fetcher=lambda: self._get_batch_status(id),
+            should_continue=batch_still_running,
+        )
+
+    def get_batch_status(self, id: str) -> BatchStatus:
+        """Retrieve the current status of a batch.
+
+        Args:
+            id: ID of the batch.
+
+        Returns:
+            BatchStatus: The current status of the batch.
+
+        Raises:
+            BatchFetchingError: If fetching the status failed.
+        """
+        return BatchStatus[self._get_batch_status(id)["status"]]
 
     def _validate_device_type(
         self,
@@ -357,11 +390,8 @@ class PasqalCloudClient:
         batch = Batch(**batch_rsp, _client=self._client)
 
         if wait:
-            while any(
-                job.status in {"PENDING", "RUNNING"} for job in batch.ordered_jobs
-            ):
-                time.sleep(RESULT_POLLING_INTERVAL)
-                batch.refresh()
+            self._wait_for_batch_terminal(batch.id)
+            batch.refresh()
 
         self.batches[batch.id] = batch
         return batch
@@ -618,6 +648,33 @@ class PasqalCloudClient:
         except HTTPError as e:
             raise JobFetchingError(e) from e
 
+    def _get_job_status(self, id: str) -> Dict[str, Any]:
+        try:
+            return self._client.get_job_status(id)
+        except HTTPError as e:
+            raise JobFetchingError(e) from e
+
+    def _wait_for_job_terminal(self, id: str) -> None:
+        """Poll the job-status endpoint until the job status is terminal."""
+        poll_status(
+            fetcher=lambda: self._get_job_status(id),
+            should_continue=job_still_running,
+        )
+
+    def get_job_status(self, id: str) -> JobStatus:
+        """Retrieve the current status of a job.
+
+        Args:
+            id: ID of the job.
+
+        Returns:
+            JobStatus: The current status of the job.
+
+        Raises:
+            JobFetchingError: If fetching the status failed.
+        """
+        return JobStatus[self._get_job_status(id)["status"]]
+
     def get_job(self, id: str, wait: bool = False) -> Job:
         """Retrieve a job's data.
 
@@ -631,11 +688,9 @@ class PasqalCloudClient:
         Raises:
             JobFetchingError: If fetching failed.
         """
-        job_rsp = self._get_job(id)
         if wait:
-            while job_rsp["status"] in ["PENDING", "RUNNING"]:
-                time.sleep(RESULT_POLLING_INTERVAL)
-                job_rsp = self._get_job(id)
+            self._wait_for_job_terminal(id)
+        job_rsp = self._get_job(id)
         return Job(**job_rsp, _client=self._client)
 
     def add_jobs(
@@ -663,11 +718,8 @@ class PasqalCloudClient:
         batch = Batch(**resp, _client=self._client)
 
         if wait:
-            while any(
-                job.status in {"PENDING", "RUNNING"} for job in batch.ordered_jobs
-            ):
-                time.sleep(RESULT_POLLING_INTERVAL)
-                batch.refresh()
+            self._wait_for_batch_terminal(batch.id)
+            batch.refresh()
         return batch
 
     def complete_batch(self, batch_id: str) -> Batch:

--- a/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
+++ b/pasqal-cloud/pasqal_cloud/pasqal_cloud_connection.py
@@ -227,8 +227,8 @@ class PasqalCloudConnection(RemoteConnection):
     @retry
     def _get_batch_status(self, batch_id: str) -> BatchStatus:
         """Gets the status of a batch from its ID."""
-        batch = self.cloud_client.get_batch(id=batch_id)
-        return BatchStatus[batch.status]
+        batch_status = self.cloud_client.get_batch_status(id=batch_id)
+        return BatchStatus[batch_status.value]
 
     @retry
     def _get_job_ids(self, batch_id: str) -> list[str]:

--- a/pasqal-cloud/pasqal_cloud/utils/mock_server.py
+++ b/pasqal-cloud/pasqal_cloud/utils/mock_server.py
@@ -39,6 +39,11 @@ class BaseMockServer(abc.ABC):
             ("GET", "/api/v2/batches/{batch_id}", self.endpoint_get_batch),
             (
                 "GET",
+                "/api/v1/batches/{batch_id}/status",
+                self.endpoint_get_batch_status,
+            ),
+            (
+                "GET",
                 "/api/v1/jobs/{job_id}/results_link",
                 self.endpoint_get_job_results,
             ),
@@ -55,6 +60,11 @@ class BaseMockServer(abc.ABC):
             ("PATCH", "/api/v2/batches/cancel", self.endpoint_patch_cancel_batches),
             ("POST", "/api/v1/batches/{batch_id}/rebatch", self.endpoint_post_rebatch),
             ("GET", "/api/v2/jobs", self.endpoint_get_jobs),
+            (
+                "GET",
+                "/api/v1/jobs/{job_id}/status",
+                self.endpoint_get_job_status,
+            ),
             ("PATCH", "/api/v2/jobs/{job_id}/cancel", self.endpoint_cancel_job),
             (
                 "PATCH",
@@ -133,6 +143,26 @@ class BaseMockServer(abc.ABC):
         Mock for GET /api/v1/batches/{batch_id}
 
         See https://docs.pasqal.com/cloud/api/core/operations/get_batch_api_v2_batches__batch_id__get/ .
+        """  # noqa: E501
+        raise NotImplementedError
+
+    def endpoint_get_batch_status(
+        self, request: Any, context: Any, matches: list[str]
+    ) -> Any:
+        """
+        Mock for GET /api/v1/batches/{batch_id}/status
+
+        See https://docs.pasqal.com/cloud/api/core/operations/get_batch_status_api_v1_batches__batch_id__status_get/ .
+        """  # noqa: E501
+        raise NotImplementedError
+
+    def endpoint_get_job_status(
+        self, request: Any, context: Any, matches: list[str]
+    ) -> Any:
+        """
+        Mock for GET /api/v1/jobs/{job_id}/status
+
+        See https://docs.pasqal.com/cloud/api/core/operations/get_job_status_api_v1_jobs__job_id__status_get/ .
         """  # noqa: E501
         raise NotImplementedError
 

--- a/pasqal-cloud/pasqal_cloud/utils/polling.py
+++ b/pasqal-cloud/pasqal_cloud/utils/polling.py
@@ -1,0 +1,78 @@
+# Copyright 2020 Pasqal Cloud Services development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Callable, Dict, TypeVar
+
+import tenacity
+
+# Wait between attempts follows ``POLL_WAIT_INITIAL_SECONDS * 2**(attempt-1)``
+# and is capped at ``POLL_WAIT_MAX_SECONDS``. With the values below the
+# schedule is: 2s, 4s, 8s, 16s, 30s, 30s, 30s, ...
+POLL_WAIT_INITIAL_SECONDS = 2
+POLL_WAIT_MAX_SECONDS = 30
+
+# Non-terminal statuses shared by both batches and jobs. As soon as neither
+# PENDING nor RUNNING jobs remain, the batch/job is considered terminal.
+NON_TERMINAL_STATUSES = frozenset({"PENDING", "RUNNING"})
+
+T = TypeVar("T")
+
+
+def poll_status(
+    fetcher: Callable[[], T],
+    should_continue: Callable[[T], bool],
+) -> T:
+    """Call ``fetcher`` repeatedly until ``should_continue(result)`` returns False.
+
+    Wait between attempts grows exponentially starting at
+    :data:`POLL_WAIT_INITIAL_SECONDS` and is capped at
+    :data:`POLL_WAIT_MAX_SECONDS`. There is no total-time or attempt-count
+    cap: the loop only exits when the predicate reports that the last
+    result is terminal, or when ``fetcher`` raises.
+
+    Args:
+        fetcher: Zero-argument callable that returns the current status
+            payload for a batch or a job.
+        should_continue: Predicate that receives the value returned by
+            ``fetcher`` and must return True to keep polling (still
+            non-terminal) or False to exit and return that value.
+
+    Returns:
+        The last value returned by ``fetcher`` (the terminal status
+        payload).
+    """
+    retryer = tenacity.Retrying(
+        wait=tenacity.wait_exponential(
+            multiplier=POLL_WAIT_INITIAL_SECONDS,
+            max=POLL_WAIT_MAX_SECONDS,
+        ),
+        stop=tenacity.stop_never,
+        retry=tenacity.retry_if_result(should_continue),
+        reraise=True,
+    )
+    return retryer(fetcher)
+
+
+def batch_still_running(status_data: dict[str, Any]) -> bool:
+    """Predicate: True while a batch still has PENDING or RUNNING jobs.
+
+    Mirrors the historical polling condition
+    ``any(job.status in {"PENDING", "RUNNING"} for job in ordered_jobs)``
+    """
+    counts = status_data.get("jobs_count_per_status") or {}
+    return any(counts.get(status, 0) > 0 for status in NON_TERMINAL_STATUSES)
+
+
+def job_still_running(status_data: dict[str, Any]) -> bool:
+    """Predicate: True while a job status is PENDING or RUNNING."""
+    return status_data.get("status") in NON_TERMINAL_STATUSES

--- a/tests/fixtures/core-fast/api/v1/batches/00000000-0000-0000-0000-000000000001/status/_.GET.json
+++ b/tests/fixtures/core-fast/api/v1/batches/00000000-0000-0000-0000-000000000001/status/_.GET.json
@@ -1,0 +1,12 @@
+{
+  "code": 200,
+  "data": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "status": "DONE",
+    "jobs_count_per_status": {
+      "DONE": 1
+    }
+  },
+  "message": "OK.",
+  "status": "success"
+}

--- a/tests/fixtures/core-fast/api/v1/batches/00000000-0000-0000-0000-000000000002/status/_.GET.json
+++ b/tests/fixtures/core-fast/api/v1/batches/00000000-0000-0000-0000-000000000002/status/_.GET.json
@@ -1,0 +1,12 @@
+{
+  "code": 200,
+  "data": {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "status": "DONE",
+    "jobs_count_per_status": {
+      "DONE": 1
+    }
+  },
+  "message": "OK.",
+  "status": "success"
+}

--- a/tests/fixtures/core-fast/api/v1/jobs/00000000-0000-0000-0000-000000022010/status/_.GET.json
+++ b/tests/fixtures/core-fast/api/v1/jobs/00000000-0000-0000-0000-000000022010/status/_.GET.json
@@ -1,0 +1,9 @@
+{
+  "code": 200,
+  "data": {
+    "id": "00000000-0000-0000-0000-000000022010",
+    "status": "DONE"
+  },
+  "message": "OK.",
+  "status": "success"
+}

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -430,9 +430,15 @@ class TestBatch:
         assert mock_request.last_request.method == "GET"
         assert (
             mock_request.last_request.url
-            == f"{self.sdk._client.endpoints.core}/api/v2/jobs?batch_id={batch.id}"
-            "&order_by=creation_order&order_by_direction=ASC"
+            == f"{self.sdk._client.endpoints.core}/api/v2/batches/{batch.id}"
         )
+        status_requests = [
+            r
+            for r in mock_request.request_history
+            if r.method == "GET"
+            and r.path == f"/core-fast/api/v1/batches/{batch.id}/status"
+        ]
+        assert len(status_requests) >= 1
         assert batch.ordered_jobs[0].batch_id == batch.id
         assert batch.ordered_jobs[0].result == self.job_result
         assert batch.ordered_jobs[0].full_result == self.job_full_result
@@ -1074,10 +1080,10 @@ class TestBatch:
                 wait=True,
             )
 
-        # Assertions to verify retry behavior
-        # There is one call to create the batch, then 6 calls
-        # to get the batch, 5 of which are retries
-        assert mock_request.call_count == 7
+        # Assertions to verify retry behavior. In the new wait flow:
+        # 1 POST /batches (create) + 1 GET /batches/{id}/status (poll returns
+        # DONE from fixture) + 6 GET /batches/{id} (final refresh, 5 retries).
+        assert mock_request.call_count == 8
         assert mock_request.last_request.method == "GET"
         assert (
             mock_request.last_request.path
@@ -1125,10 +1131,11 @@ class TestBatch:
         with contextlib.suppress(expected_exception):
             batch.add_jobs(jobs=[self.simple_job_args], wait=True)
 
-        # Assertions to verify retry behavior
-        # There is one call to create the batch, one call to add a job,
-        # then 6 calls to add the job, 5 of which are retries
-        assert mock_request.call_count == 8
+        # Assertions to verify retry behavior. In the new wait flow:
+        # 1 POST /batches (create) + 1 POST /batches/{id}/jobs (add jobs)
+        # + 1 GET /batches/{id}/status (poll returns DONE from fixture)
+        # + 6 GET /batches/{id} (final refresh, 5 retries).
+        assert mock_request.call_count == 9
         assert mock_request.last_request.method == "GET"
         assert (
             mock_request.last_request.path
@@ -1340,3 +1347,67 @@ class TestBatch:
             open=True,
         )
         assert batch.id == self.batch_id
+
+    def test_get_batch_status_returns_enum(
+        self, mock_request: requests_mock.mocker.Mocker
+    ):
+        mock_request.reset_mock()
+        mock_request.register_uri(
+            "GET",
+            f"https://apis.pasqal.cloud/core-fast/api/v1/batches/{self.batch_id}/status",
+            json={
+                "code": 200,
+                "data": {
+                    "id": self.batch_id,
+                    "status": "RUNNING",
+                    "jobs_count_per_status": {"RUNNING": 3},
+                },
+                "message": "OK.",
+                "status": "success",
+            },
+            status_code=200,
+        )
+
+        assert self.sdk.get_batch_status(self.batch_id) == BatchStatus.RUNNING
+
+    @pytest.mark.parametrize(
+        "status_name",
+        ["PENDING", "RUNNING", "DONE", "ERROR", "CANCELED", "TIMED_OUT"],
+    )
+    def test_get_batch_status_maps_all_enum_variants(
+        self, mock_request: requests_mock.mocker.Mocker, status_name: str
+    ):
+        mock_request.reset_mock()
+        mock_request.register_uri(
+            "GET",
+            f"https://apis.pasqal.cloud/core-fast/api/v1/batches/{self.batch_id}/status",
+            json={
+                "code": 200,
+                "data": {
+                    "id": self.batch_id,
+                    "status": status_name,
+                    "jobs_count_per_status": {},
+                },
+                "message": "OK.",
+                "status": "success",
+            },
+            status_code=200,
+        )
+
+        assert self.sdk.get_batch_status(self.batch_id) == BatchStatus[status_name]
+
+    def test_get_batch_status_wraps_http_error(
+        self, mock_request_exception: requests_mock.mocker.Mocker
+    ):
+        with pytest.raises(BatchFetchingError):
+            self.sdk.get_batch_status(self.batch_id)
+
+    def test_get_batch_status_does_not_fetch_full_batch(
+        self, mock_request: requests_mock.mocker.Mocker
+    ):
+        mock_request.reset_mock()
+        self.sdk.get_batch_status(self.batch_id)
+
+        called_paths = [r.path for r in mock_request.request_history]
+        assert f"/core-fast/api/v1/batches/{self.batch_id}/status" in called_paths
+        assert f"/core-fast/api/v2/batches/{self.batch_id}" not in called_paths

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -475,9 +475,66 @@ class TestJob:
         with contextlib.suppress(expected_exception):
             self.sdk.get_job(self.job_id, True)
 
-        # Assertions to verify retry behavior
-        # there are 6 calls to get the job, 5 of which are retries
-        assert mock_request.call_count == 6
+        # Assertions to verify retry behavior. In the new wait flow:
+        # 1 GET /jobs/{id}/status (poll returns DONE from fixture)
+        # + 6 GET /jobs/{id} (final fetch, 5 retries).
+        assert mock_request.call_count == 7
         assert mock_request.last_request.method == "GET"
         assert mock_request.last_request.path == f"/core-fast/api/v2/jobs/{self.job_id}"
         assert mock_request.last_request.matcher.call_count == 6
+
+    def test_get_job_status_returns_enum(
+        self, mock_request: requests_mock.mocker.Mocker
+    ):
+        mock_request.reset_mock()
+        mock_request.register_uri(
+            "GET",
+            f"https://apis.pasqal.cloud/core-fast/api/v1/jobs/{self.job_id}/status",
+            json={
+                "code": 200,
+                "data": {"id": self.job_id, "status": "RUNNING"},
+                "message": "OK.",
+                "status": "success",
+            },
+            status_code=200,
+        )
+
+        assert self.sdk.get_job_status(self.job_id) == JobStatus.RUNNING
+
+    @pytest.mark.parametrize(
+        "status_name",
+        ["PENDING", "RUNNING", "DONE", "ERROR", "CANCELED"],
+    )
+    def test_get_job_status_maps_all_enum_variants(
+        self, mock_request: requests_mock.mocker.Mocker, status_name: str
+    ):
+        mock_request.reset_mock()
+        mock_request.register_uri(
+            "GET",
+            f"https://apis.pasqal.cloud/core-fast/api/v1/jobs/{self.job_id}/status",
+            json={
+                "code": 200,
+                "data": {"id": self.job_id, "status": status_name},
+                "message": "OK.",
+                "status": "success",
+            },
+            status_code=200,
+        )
+
+        assert self.sdk.get_job_status(self.job_id) == JobStatus[status_name]
+
+    def test_get_job_status_wraps_http_error(
+        self, mock_request_exception: requests_mock.mocker.Mocker
+    ):
+        with pytest.raises(JobFetchingError):
+            self.sdk.get_job_status(self.job_id)
+
+    def test_get_job_status_does_not_fetch_full_job(
+        self, mock_request: requests_mock.mocker.Mocker
+    ):
+        mock_request.reset_mock()
+        self.sdk.get_job_status(self.job_id)
+
+        called_paths = [r.path for r in mock_request.request_history]
+        assert f"/core-fast/api/v1/jobs/{self.job_id}/status" in called_paths
+        assert f"/core-fast/api/v2/jobs/{self.job_id}" not in called_paths

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,0 +1,54 @@
+import time
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from pasqal_cloud.utils.polling import (
+    NON_TERMINAL_STATUSES,
+    batch_still_running,
+    job_still_running,
+)
+
+
+class TestPredicates:
+    @pytest.mark.parametrize(
+        ("counts", "expected"),
+        [
+            ({"PENDING": 1}, True),
+            ({"RUNNING": 3}, True),
+            ({"PENDING": 1, "RUNNING": 2, "DONE": 5}, True),
+            ({"PENDING": 0, "RUNNING": 0, "DONE": 5}, False),
+            ({"DONE": 5}, False),
+            ({"DONE": 3, "ERROR": 1, "CANCELED": 1, "TIMED_OUT": 1}, False),
+            ({}, False),
+        ],
+    )
+    def test_batch_still_running_reads_jobs_count_per_status(
+        self, counts: Dict[str, int], expected: bool
+    ) -> None:
+        assert batch_still_running({"jobs_count_per_status": counts}) is expected
+
+    def test_batch_still_running_handles_missing_jobs_count(self) -> None:
+        assert batch_still_running({}) is False
+        assert batch_still_running({"jobs_count_per_status": None}) is False
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("PENDING", True),
+            ("RUNNING", True),
+            ("DONE", False),
+            ("ERROR", False),
+            ("CANCELED", False),
+            ("TIMED_OUT", False),
+        ],
+    )
+    def test_job_still_running(self, status: str, expected: bool) -> None:
+        assert job_still_running({"status": status}) is expected
+
+    def test_job_still_running_handles_missing_status(self) -> None:
+        assert job_still_running({}) is False
+
+    def test_non_terminal_statuses_matches_predicate_semantics(self) -> None:
+        assert NON_TERMINAL_STATUSES == frozenset({"PENDING", "RUNNING"})

--- a/tests/test_remote_connections.py
+++ b/tests/test_remote_connections.py
@@ -27,6 +27,7 @@ import numpy as np
 import pulser
 import pytest
 from pasqal_cloud import DeviceTypeName
+from pasqal_cloud.utils.constants import BatchStatus as SDKBatchStatus
 from pulser.backend.config import EmulatorConfig
 from pulser.backend.remote import (
     BatchStatus,
@@ -147,6 +148,9 @@ def mock_pasqal_cloud_ovh_sdk(mock_batch):
         mock_cloud_client.reset_mock()
         mock_cloud_client.create_batch = MagicMock(return_value=mock_batch)
         mock_cloud_client.get_batch = MagicMock(return_value=mock_batch)
+        mock_cloud_client.get_batch_status = MagicMock(
+            return_value=SDKBatchStatus[mock_batch.status]
+        )
         mock_cloud_client.add_jobs = MagicMock(return_value=mock_batch)
         mock_cloud_client._close_batch = MagicMock(return_value=None)
         mock_cloud_client.get_device_specs_dict = MagicMock(
@@ -179,6 +183,9 @@ def mock_pasqal_cloud_sdk(mock_batch):
 
         mock_cloud_client.create_batch = MagicMock(return_value=mock_batch)
         mock_cloud_client.get_batch = MagicMock(return_value=mock_batch)
+        mock_cloud_client.get_batch_status = MagicMock(
+            return_value=SDKBatchStatus[mock_batch.status]
+        )
         mock_cloud_client.add_jobs = MagicMock(return_value=mock_batch)
         mock_cloud_client._close_batch = MagicMock(return_value=None)
         mock_cloud_client.get_device_specs_dict = MagicMock(
@@ -231,11 +238,13 @@ def test_remote_results(fixt_pasqal_cloud, mock_batch, with_job_id):
 
     assert remote_results.get_batch_status() == BatchStatus.DONE
 
-    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_once_with(
+    fixt_pasqal_cloud.mock_cloud_client.get_batch_status.assert_called_once_with(
         id=remote_results.batch_id
     )
+    fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_not_called()
 
     fixt_pasqal_cloud.mock_cloud_client.get_batch.reset_mock()
+    fixt_pasqal_cloud.mock_cloud_client.get_batch_status.reset_mock()
     results = remote_results.results
     fixt_pasqal_cloud.mock_cloud_client.get_batch.assert_called_with(
         id=remote_results.batch_id


### PR DESCRIPTION
### Description

Use the new status endpoint when polling batch and job results.
Use an exponential retrying mechanism when polling.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
