### PR TITLE
[FEAT] honor Retry-After header on HTTP 429 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### pasqal-cloud
 
 * Result polling on batches and jobs use new status endpoints
+* HTTP retries on 429 now honor the `Retry-After` header when present,
+  instead of always using exponential backoff
 
 
 ## [0.23.0]

--- a/examples/using_emulators.py
+++ b/examples/using_emulators.py
@@ -5,8 +5,10 @@ from pulser import Sequence, Register
 connection = PasqalCloudConnection(...)
 
 # Retrieve all QPU devices
-devices = connection.fetch_available_devices()
-device = devices["FRESNEL_CAN1"]
+while True:
+    devices = connection.fetch_available_devices()
+    device = devices["FRESNEL_CAN1"]
+    print(device)
 
 # Create a register of trapped atoms before performing operation on them
 register = Register.square(5, 5).with_automatic_layout(device)

--- a/examples/using_emulators.py
+++ b/examples/using_emulators.py
@@ -5,10 +5,8 @@ from pulser import Sequence, Register
 connection = PasqalCloudConnection(...)
 
 # Retrieve all QPU devices
-while True:
-    devices = connection.fetch_available_devices()
-    device = devices["FRESNEL_CAN1"]
-    print(device)
+devices = connection.fetch_available_devices()
+device = devices["FRESNEL_CAN1"]
 
 # Create a register of trapped atoms before performing operation on them
 register = Register.square(5, 5).with_automatic_layout(device)

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -501,11 +501,20 @@ class HTTPClient:
         return self.get_public_device_specs()
 
     def get_public_device_specs(self) -> Dict[str, str]:
-        response = self.session.request(
+        request_with_retry = retry_http_error(
+            max_retries=5,
+            retry_status_code={408, 425, 429, 500, 502, 504},
+        )(self._request_with_status_check)
+
+        response = request_with_retry(
             "GET",
             self._get_url("get_public_devices_specs"),
+            headers={
+                "content-type": "application/json",
+                "User-Agent": self.user_agent,
+            },
         )
-        response.raise_for_status()
+
         devices = response.json()["data"]
         return {device["device_type"]: device["specs"] for device in devices}
 

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -71,7 +71,6 @@ class HTTPClient:
         self.endpoints = self._make_endpoints(endpoints, region)
         self._project_id = project_id
         self.user_agent = f"PasqalCloudSDK/{sdk_version}"
-        self.user_agent = f"PasqalCloudSDKTest/handle-rate-limit"
 
         if token_provider is not None:
             self._check_token_provider(token_provider)
@@ -494,11 +493,11 @@ class HTTPClient:
         return response
 
     def get_device_specs_dict(self) -> Dict[str, str]:
-        # if self.authenticator is not None:
-        #     response: Dict[str, str] = self._authenticated_request(
-        #         "GET", self._get_url("get_devices_specs")
-        #     )["data"]
-        #     return response
+        if self.authenticator is not None:
+            response: Dict[str, str] = self._authenticated_request(
+                "GET", self._get_url("get_devices_specs")
+            )["data"]
+            return response
         return self.get_public_device_specs()
 
     def get_public_device_specs(self) -> Dict[str, str]:

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -71,6 +71,7 @@ class HTTPClient:
         self.endpoints = self._make_endpoints(endpoints, region)
         self._project_id = project_id
         self.user_agent = f"PasqalCloudSDK/{sdk_version}"
+        self.user_agent = f"PasqalCloudSDKTest/handle-rate-limit"
 
         if token_provider is not None:
             self._check_token_provider(token_provider)
@@ -493,11 +494,11 @@ class HTTPClient:
         return response
 
     def get_device_specs_dict(self) -> Dict[str, str]:
-        if self.authenticator is not None:
-            response: Dict[str, str] = self._authenticated_request(
-                "GET", self._get_url("get_devices_specs")
-            )["data"]
-            return response
+        # if self.authenticator is not None:
+        #     response: Dict[str, str] = self._authenticated_request(
+        #         "GET", self._get_url("get_devices_specs")
+        #     )["data"]
+        #     return response
         return self.get_public_device_specs()
 
     def get_public_device_specs(self) -> Dict[str, str]:

--- a/pasqal-cloud/pasqal_cloud/utils/retry.py
+++ b/pasqal-cloud/pasqal_cloud/utils/retry.py
@@ -59,14 +59,11 @@ def retry_http_error(
         @functools.wraps(func)
         def wrapper(*args: Param.args, **kwargs: Param.kwargs) -> RT:
             for iteration in range(max_retries + 1):
-                print("trying")
                 # 2 seconds, 4 seconds, 8 seconds, 16 seconds, 32 seconds
                 delay = 2**iteration
                 try:
                     response = func(*args, **kwargs)
                 except HTTPError as e:
-                    print("error")
-                    # 2 seconds, 4 seconds, 8 seconds, 16 seconds, 32 seconds
                     if (
                         e.response is None
                         or (
@@ -76,16 +73,11 @@ def retry_http_error(
                         or iteration == max_retries
                     ):
                         raise e
-                    print(f"{e.response.status_code=}")
                     if e.response.status_code == 429:
-                        print(e.response.headers)
                         retry_after = _retry_after_seconds(e.response)
-                        print(f"{retry_after=}")
                         if retry_after is not None:
                             delay = retry_after
-                    print(f"sleeping for: {delay}s")
                     time.sleep(delay)
-                    print(f"slept for: {delay}s")
                 except Exception as e:
                     if (
                         retry_exceptions

--- a/pasqal-cloud/pasqal_cloud/utils/retry.py
+++ b/pasqal-cloud/pasqal_cloud/utils/retry.py
@@ -15,7 +15,7 @@ Param = ParamSpec("Param")
 RT = TypeVar("RT")  # return type
 
 
-def _retry_after_seconds(response: Response) -> int | None:
+def _retry_after_seconds(response: "Response") -> int | None:
     """Parse Retry-After header (seconds or HTTP-date). None if absent/invalid."""
     value = response.headers.get("Retry-After")
     if value is None:

--- a/pasqal-cloud/pasqal_cloud/utils/retry.py
+++ b/pasqal-cloud/pasqal_cloud/utils/retry.py
@@ -1,12 +1,41 @@
 import functools
+import math
 import time
-from typing import Callable, Iterable, Optional, Tuple, Type, TypeVar
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import TYPE_CHECKING, Callable, Iterable, Optional, Tuple, Type, TypeVar
 
 from requests import HTTPError
 from typing_extensions import ParamSpec
 
+if TYPE_CHECKING:
+    from requests import Response
+
 Param = ParamSpec("Param")
 RT = TypeVar("RT")  # return type
+
+
+def _retry_after_seconds(response: Response) -> int | None:
+    """Parse Retry-After header (seconds or HTTP-date). None if absent/invalid."""
+    value = response.headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        # RFC 9110 Retry-After allows an HTTP-date (RFC 1123 format, e.g.
+        # "Sun, 06 Nov 1994 08:49:37 GMT"). parsedate_to_datetime parses that
+        # format (plus obsolete RFC 850/asctime variants) locale-independently,
+        # unlike strptime which depends on locale for day/month names.
+        target = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    now = datetime.now(timezone.utc)
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=timezone.utc)
+    return max(math.ceil((target - now).total_seconds()), 0)
 
 
 def retry_http_error(
@@ -44,6 +73,10 @@ def retry_http_error(
                         or iteration == max_retries
                     ):
                         raise e
+                    if e.response.status_code == 429:
+                        retry_after = _retry_after_seconds(e.response)
+                        if retry_after is not None:
+                            delay = retry_after
                     time.sleep(delay)
                 except Exception as e:
                     if (

--- a/pasqal-cloud/pasqal_cloud/utils/retry.py
+++ b/pasqal-cloud/pasqal_cloud/utils/retry.py
@@ -59,11 +59,14 @@ def retry_http_error(
         @functools.wraps(func)
         def wrapper(*args: Param.args, **kwargs: Param.kwargs) -> RT:
             for iteration in range(max_retries + 1):
+                print("trying")
                 # 2 seconds, 4 seconds, 8 seconds, 16 seconds, 32 seconds
                 delay = 2**iteration
                 try:
                     response = func(*args, **kwargs)
                 except HTTPError as e:
+                    print("error")
+                    # 2 seconds, 4 seconds, 8 seconds, 16 seconds, 32 seconds
                     if (
                         e.response is None
                         or (
@@ -73,11 +76,16 @@ def retry_http_error(
                         or iteration == max_retries
                     ):
                         raise e
+                    print(f"{e.response.status_code=}")
                     if e.response.status_code == 429:
+                        print(e.response.headers)
                         retry_after = _retry_after_seconds(e.response)
+                        print(f"{retry_after=}")
                         if retry_after is not None:
                             delay = retry_after
+                    print(f"sleeping for: {delay}s")
                     time.sleep(delay)
+                    print(f"slept for: {delay}s")
                 except Exception as e:
                     if (
                         retry_exceptions

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch
+
+import pytest
+import requests
+import requests_mock
+
+from pasqal_cloud.utils.retry import retry_http_error
+
+
+@pytest.fixture
+def make_request():
+    @retry_http_error(max_retries=3, retry_status_code={429})
+    def _make_request():
+        response = requests.get("http://test-domain")
+        response.raise_for_status()
+        return response
+
+    return _make_request
+
+
+class TestRetryAfterOn429:
+    """
+    On a 429 response, the retry decorator should sleep for the duration
+    given by the Retry-After header instead of the default exponential
+    backoff, when that header is present and valid.
+    """
+
+    def test_uses_retry_after_seconds_value(self, make_request):
+        with requests_mock.Mocker() as mock_request, patch("time.sleep") as mock_sleep:
+            mock_request.get(
+                "http://test-domain",
+                [
+                    {"status_code": 429, "headers": {"Retry-After": "12"}},
+                    {"status_code": 200},
+                ],
+            )
+            make_request()
+
+        mock_sleep.assert_called_once_with(12)
+
+    def test_uses_retry_after_http_date_value(self, make_request):
+        with requests_mock.Mocker() as mock_request, patch("time.sleep") as mock_sleep:
+            mock_request.get(
+                "http://test-domain",
+                [
+                    {
+                        "status_code": 429,
+                        "headers": {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"},
+                    },
+                    {"status_code": 200},
+                ],
+            )
+            make_request()
+
+        assert mock_sleep.call_count == 1
+        (delay,) = mock_sleep.call_args[0]
+        assert delay > 0
+
+    def test_falls_back_to_exponential_backoff_without_header(self, make_request):
+        with requests_mock.Mocker() as mock_request, patch("time.sleep") as mock_sleep:
+            mock_request.get(
+                "http://test-domain",
+                [
+                    {"status_code": 429},
+                    {"status_code": 200},
+                ],
+            )
+            make_request()
+
+        mock_sleep.assert_called_once_with(1)
+
+    def test_falls_back_to_exponential_backoff_on_invalid_header(self, make_request):
+        with requests_mock.Mocker() as mock_request, patch("time.sleep") as mock_sleep:
+            mock_request.get(
+                "http://test-domain",
+                [
+                    {"status_code": 429, "headers": {"Retry-After": "not-a-value"}},
+                    {"status_code": 200},
+                ],
+            )
+            make_request()
+
+        mock_sleep.assert_called_once_with(1)
+
+    def test_other_status_codes_ignore_retry_after(self):
+        @retry_http_error(max_retries=3, retry_status_code={500})
+        def _make_request():
+            response = requests.get("http://test-domain")
+            response.raise_for_status()
+            return response
+
+        with requests_mock.Mocker() as mock_request, patch("time.sleep") as mock_sleep:
+            mock_request.get(
+                "http://test-domain",
+                [
+                    {"status_code": 500, "headers": {"Retry-After": "99"}},
+                    {"status_code": 200},
+                ],
+            )
+            _make_request()
+
+        mock_sleep.assert_called_once_with(1)


### PR DESCRIPTION
### Description

Sleep for the server-specified duration (delay-seconds or HTTP-date) instead of the default exponential backoff when a 429 includes Retry-After.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
