### PR TITLE
fix(http-client): extend read timeout for batch creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Next release
 
+### pasqal-cloud
+
+* Fixes
+    - Extend the read timeout to 5 minutes for batch creation, which can take
+      longer than the default 30s
+
 ## [0.24.0]
 
 ### pasqal-cloud

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -262,7 +262,7 @@ class HTTPClient:
         resp = request_with_retry(
             method,
             url,
-            timeout=TIMEOUT,
+            timeout=(TIMEOUT, None),
             headers=headers,
             auth=self.authenticator,
             params=params,

--- a/pasqal-cloud/pasqal_cloud/http_client.py
+++ b/pasqal-cloud/pasqal_cloud/http_client.py
@@ -18,7 +18,7 @@ import json
 import os
 import warnings
 from getpass import getpass
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 from uuid import UUID
 
 import requests
@@ -42,6 +42,7 @@ from pasqal_cloud.utils.jsend import JobResult, JSendPayload
 from pasqal_cloud.utils.retry import retry_http_error
 
 TIMEOUT = 30  # client http requests timeout after 30s
+BATCH_CREATION_TIMEOUT = 300  # batch creation can take longer, allow 5min
 
 
 # Env variable to disable SSL verification. Should be used only in testing environement
@@ -226,6 +227,7 @@ class HTTPClient:
         payload: Optional[Union[Mapping, Sequence[Mapping], Sequence[str]]] = None,
         params: Optional[Mapping[str, Any]] = None,
         gziped: bool = False,
+        timeout: Union[float, Tuple[float, Optional[float]]] = TIMEOUT,
     ) -> JSendPayload:
         if self.authenticator is None:
             raise ValueError(
@@ -262,7 +264,7 @@ class HTTPClient:
         resp = request_with_retry(
             method,
             url,
-            timeout=TIMEOUT,
+            timeout=timeout,
             headers=headers,
             auth=self.authenticator,
             params=params,
@@ -326,7 +328,13 @@ class HTTPClient:
     def send_batch(self, batch_data: Dict[str, Any]) -> Dict[str, Any]:
         batch_data.update({"project_id": self.project_id})
         response: Dict[str, Any] = self._authenticated_request(
-            "POST", self._get_url("send_batch"), batch_data, gziped=True
+            "POST",
+            self._get_url("send_batch"),
+            batch_data,
+            gziped=True,
+            # Batch creation can take longer than TIMEOUT server-side
+            # (e.g. large sequences), so it gets an extended read timeout.
+            timeout=(TIMEOUT, BATCH_CREATION_TIMEOUT),
         )["data"]
         return response
 


### PR DESCRIPTION

### Description

Server-side processing on slow endpoints (e.g. batch creation) could
outlast the read timeout, aborting the client before the response
arrived even though the request succeeded. Callers then retried
manually, duplicating batches/jobs and burning credits.

Reverting the global timeout removal: only send_batch now gets an
extended 5min read timeout (BATCH_CREATION_TIMEOUT), other requests
keep the default 30s.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [x] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [x] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [x] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
