### PR TITLE
[IMPROVEMENT] support auth0-python 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### pasqal-cloud
 
 * Result polling on batches and jobs use new status endpoints
+* Support `auth0-python` 4.x (pin moved from `>= 3.23.1, <4.0.0` to `>= 4.7.2, <5.0.0`)
 
 
 ## [0.23.0]

--- a/pasqal-cloud/setup.py
+++ b/pasqal-cloud/setup.py
@@ -64,7 +64,7 @@ setup(
     ],
     url="https://github.com/pasqal-io/pasqal-cloud",
     install_requires=[
-        "auth0-python >= 3.23.1, <4.0.0",
+        "auth0-python >= 4.7.2, <5.0.0",
         "requests>=2.25.1, <3.0.0",
         "pyjwt[crypto]>=2.5.0, <3.0.0",
         "pydantic >= 2.6.0, <3.0.0",

--- a/tests/test_doubles/authentication.py
+++ b/tests/test_doubles/authentication.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from auth0.v3.exceptions import Auth0Error
+from auth0.exceptions import Auth0Error
 from pasqal_cloud.authentication import PasswordGrantTokenProvider
 
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 import requests
 import requests_mock
-from auth0.v3.exceptions import Auth0Error
+from auth0.exceptions import Auth0Error
 from pasqal_cloud import (
     AUTH0_CONFIG,
     Auth0Conf,


### PR DESCRIPTION
### Description

Bumps the `auth0-python` pin from `>= 3.23.1, <4.0.0` to `>= 4.7.2, <5.0.0`.

The `<4.0.0` pin makes `pasqal-cloud` uninstallable alongside any package that requires `auth0-python >= 4` — we hit this with [`aqt-connector`](https://pypi.org/project/aqt-connector/) (`auth0-python >= 4.7.2, <5`), which is unsatisfiable against every released `pasqal-cloud`.

The bump turns out to be nearly free, because **the library itself no longer imports `auth0`**. Token exchange is done with plain `requests.post` in `PasswordGrantTokenProvider._query_token`, and the last library-side `auth0` import was removed in 53294be. The only remaining usage anywhere in the repo is the `Auth0Error` exception in two test files:

- `tests/test_doubles/authentication.py`
- `tests/test_http_client.py`

`auth0-python` 4.0.0 removed the `auth0.v3` namespace, so those two imports move to `auth0.exceptions`. The `Auth0Error` constructor signature is unchanged, and the `pytest.raises(Auth0Error)` assertions pass as-is. The other 4.0.0 breaking change (removal of deprecated methods) doesn't apply, since no `auth0` methods are called.

Note the import change is not backward compatible — `auth0.exceptions` does not exist in 3.x — so this moves the floor to 4.x rather than widening the range.

#### Remaining Tasks

You may want to go further than this PR does: since no library code imports `auth0`, `auth0-python` could move out of `install_requires` into the `dev` extra entirely, dropping a phantom runtime dependency for all users and removing this class of conflict permanently. I verified the package imports and works with `auth0-python` uninstalled. I kept this PR to the minimal pin bump since dropping a declared runtime dependency is your call.

`VERSION.txt` is not bumped (marked PASQAL-developers-only in the template).

#### Breaking changes

None for `pasqal-cloud` users, beyond the raised `auth0-python` floor.

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}

#### Documentation

- [x] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [x] Unit tests have been added or adjusted.
- [x] Tests were run locally.

Full suite on Python 3.11 with `auth0-python` 4.13.0 installed: **325 passed**. Same count as the baseline on 3.24.1. `mypy` (strict) reports no issues.
