### PR TITLE
[DOC] publish versioned GitHub Pages docs per release tag

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,6 +11,10 @@ on:
 
 concurrency: preview-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -1,9 +1,8 @@
 name: Publish MkDocs documentation to gh-pages
 on:
-  push:
-    tags:
-      - "*"
-  workflow_dispatch:
+  release:
+    types:
+      - published
 permissions:
   contents: write
 concurrency:
@@ -11,22 +10,17 @@ concurrency:
   cancel-in-progress: false
 jobs:
   deploy:
-    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Determine docs version
+      - name: Verify tag matches VERSION.txt
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            version="${GITHUB_REF#refs/tags/}"
-            expected=$(cat VERSION.txt)
-            if [ "$version" != "$expected" ]; then
-              echo "Tag '$version' does not match VERSION.txt '$expected'"
-              exit 1
-            fi
-          else
-            version=$(cat VERSION.txt)
+          version="${GITHUB_REF_NAME}"
+          expected=$(cat VERSION.txt)
+          if [ "$version" != "$expected" ]; then
+            echo "Tag '$version' does not match VERSION.txt '$expected'"
+            exit 1
           fi
           echo "Publishing docs version '$version'"
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -3,22 +3,33 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 permissions:
   contents: write
+concurrency:
+  group: docs-gh-pages-publish
+  cancel-in-progress: false
 jobs:
   deploy:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Verify tag matches VERSION.txt
+      - name: Determine docs version
+        id: version
         run: |
-          # strips refs/tags/ prefix from GITHUB_REF
-          tag="${GITHUB_REF#refs/tags/}"
-          version=$(cat VERSION.txt)
-          if [ "$tag" != "$version" ]; then
-            echo "Tag '$tag' does not match VERSION.txt '$version'"
-            exit 1
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            version="${GITHUB_REF#refs/tags/}"
+            expected=$(cat VERSION.txt)
+            if [ "$version" != "$expected" ]; then
+              echo "Tag '$version' does not match VERSION.txt '$expected'"
+              exit 1
+            fi
+          else
+            version=$(cat VERSION.txt)
           fi
+          echo "Publishing docs version '$version'"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -35,4 +46,8 @@ jobs:
             doc-publish-
       - run: pip install .[docs]
         working-directory: pasqal-cloud
-      - run: mkdocs gh-deploy --force
+      - name: Deploy versioned docs
+        run: |
+          git fetch origin gh-pages
+          mike deploy --push --update-aliases "${{ steps.version.outputs.version }}" latest
+          mike set-default --push latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Result polling on batches and jobs use new status endpoints
 
+
 ## [0.23.0]
 
 ### pulser-pasqal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,45 +6,41 @@ All notable changes to this project will be documented in this file.
 
 ### pasqal-cloud
 
-* Result polling on batches and jobs use new status endpoints
-* Publish versioned documentation per release tag on GitHub Pages
-
-
+- Result polling on batches and jobs use new status endpoints
 
 ## [0.23.0]
 
 ### pulser-pasqal
 
-* Pin pasqal-cloud to 0.22.0
-* Add deprecation notices regarding pasqal-cloud merge
+- Pin pasqal-cloud to 0.22.0
+- Add deprecation notices regarding pasqal-cloud merge
 
 ### pasqal-cloud
 
-* Replace backoff as unmaintained anymore by tenacity
-* Merge pulser-pasqal into this package
-    - classes were renamed and deprecated ones removed
+- Replace backoff as unmaintained anymore by tenacity
+- Merge pulser-pasqal into this package
+  - classes were renamed and deprecated ones removed
 
-* Changes
-    - runs from job_params is now honored for emulator backends
+- Changes
+  - runs from job_params is now honored for emulator backends
 
-* Fixes
-    - correctly wait for jobs to finish within open_batch context manager
-
+- Fixes
+  - correctly wait for jobs to finish within open_batch context manager
 
 ## [0.22.0]
 
 ### pasqal-cloud
 
-* Add gzip compression for big payloads on `SDK.create_batch` and `SDK.add_jobs` methods
+- Add gzip compression for big payloads on `SDK.create_batch` and `SDK.add_jobs` methods
   - Can be disabled by setting the `PASQAL_SKIP_GZIP_REQUEST_BODY` environment variable
-* Allow defining a sequence at job level when creating a batch
+- Allow defining a sequence at job level when creating a batch
   - `serialized_sequence` is now optional in `SDK.create_batch`. If not specified, all jobs must define their own sequence
 
 ## [0.21.0]
 
 ### pasqal-cloud
 
-* Add region support
+- Add region support
   - `sa`: Saudi-Arabia platform
   - `fr`: European platform
 
@@ -52,49 +48,49 @@ All notable changes to this project will be documented in this file.
 
 ### pulser-pasqal
 
-* Make 'job_params' optional in RemoteEmulatorBackend
-* Add PasqalCloud.get_results()
+- Make 'job_params' optional in RemoteEmulatorBackend
+- Add PasqalCloud.get_results()
 
 ## [0.20.7]
 
 ### pulser-pasqal
 
-* Introduce a new Backend for EMU SV on `pulser-pasqal` (
+- Introduce a new Backend for EMU SV on `pulser-pasqal` (
   see [documentation](https://docs.pasqal.com/cloud/emulators-integration/))
 
 ## [0.20.6]
 
 ### pulser-pasqal
 
-* Fixes:
-    - Fix retrieval of results for batches using parametrized sequence
-    - Deserialize all results returned by the emulator instead of solely the bitstrings counter
-* Bump pulser-core minimum version to >=1.6
+- Fixes:
+  - Fix retrieval of results for batches using parametrized sequence
+  - Deserialize all results returned by the emulator instead of solely the bitstrings counter
+- Bump pulser-core minimum version to >=1.6
 
 ## [0.20.5]
 
 ### pasqal-cloud
 
-* Added warning on use of EMU_TN as `device_type` on batch creation
-* Fixed pydantic warning for use of `model_fields` on instance instead of class
-* Enable multi-qpu support by removing hard-coded reference to Fresnel
+- Added warning on use of EMU_TN as `device_type` on batch creation
+- Fixed pydantic warning for use of `model_fields` on instance instead of class
+- Enable multi-qpu support by removing hard-coded reference to Fresnel
 
 ### pulser-pasqal
 
-* Bump pulser-core minimum version to >1.4
+- Bump pulser-core minimum version to >1.4
 
 ## [0.20.4]
 
 ### pulser-pasqal
 
-* Introduce a new Backend for EMU FREE on `pulser-pasqal`
-* Introduce a new Backend for EMU MPS on `pulser-pasqal`
-* New MockSDK, used for testing code that uses this SDK
+- Introduce a new Backend for EMU FREE on `pulser-pasqal`
+- Introduce a new Backend for EMU MPS on `pulser-pasqal`
+- New MockSDK, used for testing code that uses this SDK
 
 ### pasqal-cloud
 
-* Added `switch_to_project("project_id")` method to change the project linked to your SDK
-* Added `get_all_projects()` method to get the list of all active projects the user is a member
+- Added `switch_to_project("project_id")` method to change the project linked to your SDK
+- Added `get_all_projects()` method to get the list of all active projects the user is a member
 
 ## [0.20.4dev0]
 
@@ -178,11 +174,11 @@ _released `2024-10-02`_
 ### Changed
 
 - Now these methods are using V2 endpoints:
-    - Cancel a batch
-    - Cancel a job
-    - Cancel a group of jobs
-    - Add jobs to a batch
-    - Close a batch
+  - Cancel a batch
+  - Cancel a job
+  - Cancel a group of jobs
+  - Add jobs to a batch
+  - Close a batch
 
 ## [0.12.1] - 2024-09-11
 
@@ -298,8 +294,8 @@ A Batch that does not accept new jobs is now called "closed" instead of "complet
 ### Added
 
 - Added feature to create an "open" batch.
-    - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
-    - To add jobs to an open batch, use the `add_jobs` method.
+  - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
+  - To add jobs to an open batch, use the `add_jobs` method.
 - Updated documentation to add examples to create open batches.
 - The `wait` argument now waits for all the jobs to be terminated instead of waiting for the batch to be terminated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### pasqal-cloud
 
 * Result polling on batches and jobs use new status endpoints
+* Publish versioned documentation per release tag on GitHub Pages
+
 
 
 ## [0.23.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,42 +6,43 @@ All notable changes to this project will be documented in this file.
 
 ### pasqal-cloud
 
-- Result polling on batches and jobs use new status endpoints
+* Result polling on batches and jobs use new status endpoints
 
 
 ## [0.23.0]
 
 ### pulser-pasqal
 
-- Pin pasqal-cloud to 0.22.0
-- Add deprecation notices regarding pasqal-cloud merge
+* Pin pasqal-cloud to 0.22.0
+* Add deprecation notices regarding pasqal-cloud merge
 
 ### pasqal-cloud
 
-- Replace backoff as unmaintained anymore by tenacity
-- Merge pulser-pasqal into this package
-  - classes were renamed and deprecated ones removed
+* Replace backoff as unmaintained anymore by tenacity
+* Merge pulser-pasqal into this package
+    - classes were renamed and deprecated ones removed
 
-- Changes
-  - runs from job_params is now honored for emulator backends
+* Changes
+    - runs from job_params is now honored for emulator backends
 
-- Fixes
-  - correctly wait for jobs to finish within open_batch context manager
+* Fixes
+    - correctly wait for jobs to finish within open_batch context manager
+
 
 ## [0.22.0]
 
 ### pasqal-cloud
 
-- Add gzip compression for big payloads on `SDK.create_batch` and `SDK.add_jobs` methods
+* Add gzip compression for big payloads on `SDK.create_batch` and `SDK.add_jobs` methods
   - Can be disabled by setting the `PASQAL_SKIP_GZIP_REQUEST_BODY` environment variable
-- Allow defining a sequence at job level when creating a batch
+* Allow defining a sequence at job level when creating a batch
   - `serialized_sequence` is now optional in `SDK.create_batch`. If not specified, all jobs must define their own sequence
 
 ## [0.21.0]
 
 ### pasqal-cloud
 
-- Add region support
+* Add region support
   - `sa`: Saudi-Arabia platform
   - `fr`: European platform
 
@@ -49,49 +50,49 @@ All notable changes to this project will be documented in this file.
 
 ### pulser-pasqal
 
-- Make 'job_params' optional in RemoteEmulatorBackend
-- Add PasqalCloud.get_results()
+* Make 'job_params' optional in RemoteEmulatorBackend
+* Add PasqalCloud.get_results()
 
 ## [0.20.7]
 
 ### pulser-pasqal
 
-- Introduce a new Backend for EMU SV on `pulser-pasqal` (
+* Introduce a new Backend for EMU SV on `pulser-pasqal` (
   see [documentation](https://docs.pasqal.com/cloud/emulators-integration/))
 
 ## [0.20.6]
 
 ### pulser-pasqal
 
-- Fixes:
-  - Fix retrieval of results for batches using parametrized sequence
-  - Deserialize all results returned by the emulator instead of solely the bitstrings counter
-- Bump pulser-core minimum version to >=1.6
+* Fixes:
+    - Fix retrieval of results for batches using parametrized sequence
+    - Deserialize all results returned by the emulator instead of solely the bitstrings counter
+* Bump pulser-core minimum version to >=1.6
 
 ## [0.20.5]
 
 ### pasqal-cloud
 
-- Added warning on use of EMU_TN as `device_type` on batch creation
-- Fixed pydantic warning for use of `model_fields` on instance instead of class
-- Enable multi-qpu support by removing hard-coded reference to Fresnel
+* Added warning on use of EMU_TN as `device_type` on batch creation
+* Fixed pydantic warning for use of `model_fields` on instance instead of class
+* Enable multi-qpu support by removing hard-coded reference to Fresnel
 
 ### pulser-pasqal
 
-- Bump pulser-core minimum version to >1.4
+* Bump pulser-core minimum version to >1.4
 
 ## [0.20.4]
 
 ### pulser-pasqal
 
-- Introduce a new Backend for EMU FREE on `pulser-pasqal`
-- Introduce a new Backend for EMU MPS on `pulser-pasqal`
-- New MockSDK, used for testing code that uses this SDK
+* Introduce a new Backend for EMU FREE on `pulser-pasqal`
+* Introduce a new Backend for EMU MPS on `pulser-pasqal`
+* New MockSDK, used for testing code that uses this SDK
 
 ### pasqal-cloud
 
-- Added `switch_to_project("project_id")` method to change the project linked to your SDK
-- Added `get_all_projects()` method to get the list of all active projects the user is a member
+* Added `switch_to_project("project_id")` method to change the project linked to your SDK
+* Added `get_all_projects()` method to get the list of all active projects the user is a member
 
 ## [0.20.4dev0]
 
@@ -175,11 +176,11 @@ _released `2024-10-02`_
 ### Changed
 
 - Now these methods are using V2 endpoints:
-  - Cancel a batch
-  - Cancel a job
-  - Cancel a group of jobs
-  - Add jobs to a batch
-  - Close a batch
+    - Cancel a batch
+    - Cancel a job
+    - Cancel a group of jobs
+    - Add jobs to a batch
+    - Close a batch
 
 ## [0.12.1] - 2024-09-11
 
@@ -295,8 +296,8 @@ A Batch that does not accept new jobs is now called "closed" instead of "complet
 ### Added
 
 - Added feature to create an "open" batch.
-  - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
-  - To add jobs to an open batch, use the `add_jobs` method.
+    - To create an open batch, set the `complete` argument to `True` in the `create_batch` method of the SDK.
+    - To add jobs to an open batch, use the `add_jobs` method.
 - Updated documentation to add examples to create open batches.
 - The `wait` argument now waits for all the jobs to be terminated instead of waiting for the batch to be terminated.
 

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ pre-commit install
 
 For an overview of how to use each library, please refer to
 
-- [The `pasqal-cloud` README](https://pasqal-io.github.io/pasqal-cloud/#getting-started)
+- [The `pasqal-cloud` README](https://pasqal-io.github.io/pasqal-cloud/latest/getting-started/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,3 +65,7 @@ markdown_extensions:
 extra_css:
   # from Qadence, to get paddings on blocks
   - extras/css/mkdocstrings.css
+
+extra:
+  version:
+    provider: mike

--- a/pasqal-cloud/README.md
+++ b/pasqal-cloud/README.md
@@ -44,5 +44,5 @@ print(results.results)
 ## Documentation
 
 For full usage guides, authentication options, emulator configuration, and API reference,
-visit the [Github Pages documentation](https://pasqal-io.github.io/pasqal-cloud/)
+visit the [Github Pages documentation](https://pasqal-io.github.io/pasqal-cloud/latest/)
 or the **[Pasqal documentation](https://docs.pasqal.com/cloud/pasqal-cloud/)**.

--- a/pasqal-cloud/setup.py
+++ b/pasqal-cloud/setup.py
@@ -85,6 +85,7 @@ setup(
             "mkdocs-material==9.5.50",
             "mkdocstrings==0.27.0",
             "mkdocstrings-python==1.13.0",
+            "mike==2.2.0",
         },
     },
 )


### PR DESCRIPTION
## Summary
- Keep a documentation snapshot for each release tag on GitHub Pages using [mike](https://github.com/jimporter/mike), instead of overwriting `gh-pages` with `mkdocs gh-deploy --force`.
- Enable the Material version selector (`/0.23.0/`, `/latest/`, root redirects to `latest`) and point README links at `/latest/`.
- Allow a one-shot publish from `main` via `workflow_dispatch` so `0.23.0` can be deployed without cutting a new tag. PR previews stay under `pr-preview/`.

### Notes
- `VERSION.txt` is unchanged: this is docs hosting, not an SDK release.
- Backfilling older supported tags (`0.20.4`–`0.22.0`) is left as a follow-up.
- On the frontend side we'll have to update the scrap to https://docs.pasqal.com/cloud/pasqal-cloud/latest

Closes #288.
