### PR TITLE
[FEAT] added mike and versioning to pasqal cloud

### DIFF
--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -35,4 +35,8 @@ jobs:
             doc-publish-
       - run: pip install .[docs]
         working-directory: pasqal-cloud
-      - run: mkdocs gh-deploy --force
+      - name: Deploy versioned docs
+        run: |
+          git fetch origin gh-pages
+          mike deploy --push --update-aliases "${GITHUB_REF#refs/tags/}" latest
+          mike set-default --push latest

--- a/.github/workflows/publish-doc-to-gh-pages.yml
+++ b/.github/workflows/publish-doc-to-gh-pages.yml
@@ -1,6 +1,8 @@
 name: Publish MkDocs documentation to gh-pages
 on:
   push:
+    branches:
+      - main
     tags:
       - "*"
 permissions:
@@ -11,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify tag matches VERSION.txt
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           # strips refs/tags/ prefix from GITHUB_REF
           tag="${GITHUB_REF#refs/tags/}"
@@ -35,8 +38,13 @@ jobs:
             doc-publish-
       - run: pip install .[docs]
         working-directory: pasqal-cloud
+      - name: Fetch gh-pages
+        run: git fetch origin gh-pages --depth=1
+      - name: Deploy dev docs
+        if: github.ref == 'refs/heads/main'
+        run: mike deploy --push --update-aliases dev
       - name: Deploy versioned docs
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          git fetch origin gh-pages
           mike deploy --push --update-aliases "${GITHUB_REF#refs/tags/}" latest
           mike set-default --push latest

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ pre-commit install
 
 For an overview of how to use each library, please refer to
 
-- [The `pasqal-cloud` README](https://pasqal-io.github.io/pasqal-cloud/#getting-started)
+- [The `pasqal-cloud` README](https://pasqal-io.github.io/pasqal-cloud/latest/getting-started/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,10 @@ markdown_extensions:
       base_path: ["."]
       check_paths: true
 
+extra:
+  version:
+    provider: mike
+
 extra_css:
   # from Qadence, to get paddings on blocks
   - extras/css/mkdocstrings.css

--- a/pasqal-cloud/README.md
+++ b/pasqal-cloud/README.md
@@ -44,5 +44,5 @@ print(results.results)
 ## Documentation
 
 For full usage guides, authentication options, emulator configuration, and API reference,
-visit the [Github Pages documentation](https://pasqal-io.github.io/pasqal-cloud/)
+visit the [Github Pages documentation](https://pasqal-io.github.io/pasqal-cloud/latest/)
 or the **[Pasqal documentation](https://docs.pasqal.com/cloud/pasqal-cloud/)**.

--- a/pasqal-cloud/setup.py
+++ b/pasqal-cloud/setup.py
@@ -85,6 +85,7 @@ setup(
             "mkdocs-material==9.5.50",
             "mkdocstrings==0.27.0",
             "mkdocstrings-python==1.13.0",
+            "mike==2.2.0",
         },
     },
 )

--- a/pulser-pasqal/README.md
+++ b/pulser-pasqal/README.md
@@ -2,4 +2,4 @@
 
 This package is replaced by [pasqal-cloud](https://pypi.org/project/pasqal-cloud/) and is going to be removed in the future.
 
-Please check the [migration guide](https://pasqal-io.github.io/pasqal-cloud/migrating-from-pulser-pasqal/) toward pasqal-cloud.
+Please check the [migration guide](https://pasqal-io.github.io/pasqal-cloud/latest/migrating-from-pulser-pasqal/) toward pasqal-cloud.


### PR DESCRIPTION
### Description

Versioned MkDocs documentation with mike.

On each release tag, docs are deployed as a versioned snapshot aliased as `latest`, instead of overwriting gh-pages with `mkdocs gh-deploy --force`. Documentation links now point to `/latest/`.

Preview is here https://thomasbaronnet.github.io/pasqal-cloud/latest/

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [x] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [x] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
