### PR TITLE
[FEAT] Added doc portal pr preview 

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -98,7 +98,7 @@ jobs:
           qr-code: false
 
   portal-preview:
-    name: Deploy portal preview
+    name: Deploy doc-portal preview
     needs: [deploy]
     if: |
       github.event.action != 'closed' &&
@@ -137,6 +137,7 @@ jobs:
           docker run --rm \
             --volume "$PWD/portal-dist:/out" \
             --env BUILD_CONFIG='{"pasqalCloud":"https://pasqal-io.github.io/pasqal-cloud/pr-preview/pr-${{ github.event.pull_request.number }}/"}' \
+            --env ASTRO_BASE="/pasqal-cloud/${PORTAL_PREVIEW_PATH}/" \
             --entrypoint sh \
             "$DOC_PORTAL_IMAGE" \
             -c 'sh /app/docker/doc-portal-rebuild-source.sh pasqalCloud && cp -r /app/packages/doc-portal/dist/. /out/'
@@ -157,8 +158,7 @@ jobs:
           message: |
             Doc portal preview: https://pasqal-io.github.io/pasqal-cloud/${{ env.PORTAL_PREVIEW_PATH }}/cloud/pasqal-cloud/
 
-            Built from ${{ github.event.pull_request.head.sha }}. Only this product is included.
-
+            Built from ${{ github.event.pull_request.head.sha }}.
   portal-cleanup:
     name: Cleanup portal preview
     if: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -110,7 +110,7 @@ jobs:
       pull-requests: write # sticky comment
     env:
       PORTAL_PREVIEW_PATH: portal-preview/pr-${{ github.event.pull_request.number }}
-      DOC_PORTAL_IMAGE: ${{ secrets.DOC_PORTAL_IMAGE }}
+      DOC_PORTAL_IMAGE: europe-west9-docker.pkg.dev/pasqal-artifact/frontend/doc-portal:source-runtime
     steps:
       - name: Checkout the base commit, never the PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -118,18 +118,12 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v4
         with:
-          credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA }}
-
-      - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: |
-          host="${DOC_PORTAL_IMAGE%%/*}"
-          gcloud auth configure-docker "$host" --quiet
+          registry: europe-west9-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA }}
 
       - name: Pull the doc portal image
         run: docker pull "$DOC_PORTAL_IMAGE"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,8 +75,8 @@ jobs:
       (github.event.action == 'closed' || needs.build.result == 'success')
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # push the preview to the gh-pages branch
-      pull-requests: write  # leave/update the sticky preview comment
+      contents: write # push the preview to the gh-pages branch
+      pull-requests: write # leave/update the sticky preview comment
     steps:
       - name: Checkout the base commit, never the PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -96,3 +96,104 @@ jobs:
           source-dir: ./site/
           preview-branch: gh-pages
           qr-code: false
+
+  portal-preview:
+    name: Deploy portal preview
+    needs: [deploy]
+    if: |
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.deploy.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # publish under portal-preview/pr-<n>/ on gh-pages
+      pull-requests: write # sticky comment
+    env:
+      PORTAL_PREVIEW_PATH: portal-preview/pr-${{ github.event.pull_request.number }}
+      DOC_PORTAL_IMAGE: ${{ secrets.DOC_PORTAL_IMAGE }}
+    steps:
+      - name: Checkout the base commit, never the PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: |
+          host="${DOC_PORTAL_IMAGE%%/*}"
+          gcloud auth configure-docker "$host" --quiet
+
+      - name: Pull the doc portal image
+        run: docker pull "$DOC_PORTAL_IMAGE"
+
+      - name: Wait for GitHub Pages # Maybe later: poll with curl until the mkdocs preview URL responds.
+        run: sleep 60
+
+      - name: Build the portal preview
+        run: |
+          mkdir -p portal-dist
+          docker run --rm \
+            --volume "$PWD/portal-dist:/out" \
+            --env BUILD_CONFIG='{"pasqalCloud":"https://pasqal-io.github.io/pasqal-cloud/pr-preview/pr-${{ github.event.pull_request.number }}/"}' \
+            --entrypoint sh \
+            "$DOC_PORTAL_IMAGE" \
+            -c 'sh /app/docker/doc-portal-rebuild-source.sh pasqalCloud && cp -r /app/packages/doc-portal/dist/. /out/'
+
+      - name: Publish to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: portal-dist
+          branch: gh-pages
+          target-folder: ${{ env.PORTAL_PREVIEW_PATH }}
+          force: false
+          commit-message: Doc portal preview for PR ${{ github.event.pull_request.number }}
+
+      - name: Comment the preview link on the PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: doc-portal-preview
+          message: |
+            Doc portal preview: https://pasqal-io.github.io/pasqal-cloud/${{ env.PORTAL_PREVIEW_PATH }}/cloud/pasqal-cloud/
+
+            Built from ${{ github.event.pull_request.head.sha }}. Only this product is included.
+
+  portal-cleanup:
+    name: Cleanup portal preview
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: gh-pages
+
+      - name: Remove the preview folder
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git rm -r --ignore-unmatch "portal-preview/pr-${{ github.event.pull_request.number }}"
+          if git diff --cached --quiet; then
+            echo "Nothing to clean."
+            exit 0
+          fi
+          git commit -m "Remove doc portal preview for PR ${{ github.event.pull_request.number }}"
+          git push
+
+      - name: Remove the preview comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: doc-portal-preview
+          delete: true


### PR DESCRIPTION
### Description

Add a doc portal preview on PRs (next to the mkdocs one).

We pull the doc-portal image, build it with the PR mkdocs URL + ASTRO_BASE, and publish it under portal-preview/pr-<n>/. When the PR is closed we clean it up.

#### Remaining Tasks

<!-- Tasks left to do, either in this PR or as future work -->

#### Related PRs in other projects (PASQAL developers only)

<!-- Links of others related PR to this one -->

#### Additional merge criteria

<!-- Here, add any extra criteria you consider mandatory for merging on top of the usual criteria -->

#### Breaking changes

<!-- Here, add all the breaking changes that this PR involves if there is any -->

### Checklist

- [ ] The title of the PR follows the right format: [{Label}] {Short Message}. Label examples: IMPROVEMENT, FIX, REFACTORING... Short message is about what your PR changes.

#### Versioning (PASQAL developers only)

- [ ] Update the version of pasqal-cloud in `VERSION.txt` following the changes in your PR and by using [semantic versioning](https://semver.org/).

#### Documentation

- [ ] Update CHANGELOG.md with a description explaining briefly the changes to the users.

#### Tests

- [ ] Unit tests have been added or adjusted.
- [ ] Tests were run locally.

#### Internal tests pipeline (PASQAL developers only)
- [ ] Update and run the internal tests while targeting the branch of this PR.
 If your PR hasn't changed any functionality, it still needs to be validated against internal tests.

#### After updating the version (PASQAL developers only)

- [ ] Open a PR on the internal tests that updates the version used for the pasqal-cloud backward compatibility tests.
